### PR TITLE
Allow convert_file_resources to work even in absence of environments/production

### DIFF
--- a/lib/octocatalog-diff/catalog-util/fileresources.rb
+++ b/lib/octocatalog-diff/catalog-util/fileresources.rb
@@ -30,7 +30,8 @@ module OctocatalogDiff
         # there is on-demand, explicit error checking for each file within the modification loop.
         return unless compilation_dir.is_a?(String) && compilation_dir != ''
 
-        # Making sure that compilation_dir/environments/production exists. Otherwise, try to find
+        # Making sure that compilation_dir/environments/production/modules exists (and by inference,
+        # that compilation_dir/environments/production is pointing at the right place). Otherwise, try to find
         # compilation_dir/modules. If neither of those exist, this code can't run.
         env_dir = File.join(compilation_dir, 'environments', 'production')
         unless File.directory?(File.join(env_dir, 'modules'))

--- a/lib/octocatalog-diff/catalog-util/fileresources.rb
+++ b/lib/octocatalog-diff/catalog-util/fileresources.rb
@@ -29,7 +29,14 @@ module OctocatalogDiff
         # Calculate compilation directory. There is not explicit error checking here because
         # there is on-demand, explicit error checking for each file within the modification loop.
         return unless compilation_dir.is_a?(String) && compilation_dir != ''
+
+        # Making sure that compilation_dir/environments/production exists. Otherwise, try to find
+        # compilation_dir/modules. If neither of those exist, this code can't run.
         env_dir = File.join(compilation_dir, 'environments', 'production')
+        unless File.directory?(File.join(env_dir, 'modules'))
+          return unless File.directory?(File.join(compilation_dir, 'modules'))
+          env_dir = compilation_dir
+        end
 
         # Modify the resources
         resources.map! do |resource|


### PR DESCRIPTION
## Overview

This pull request avoids an exception being thrown when:
- Catalog caching is enabled
- The "to" branch is `.`
- The `environments/production` symlink is missing

The changed code checks additional paths, and skips the code that will be problematic when the Puppet repository is not set up as expected. 

## Checklist

- [x] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [x] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.