### PR TITLE
Ignore any kill errors for the testing SSL server

### DIFF
--- a/spec/octocatalog-diff/integration/pe_enc_spec.rb
+++ b/spec/octocatalog-diff/integration/pe_enc_spec.rb
@@ -11,9 +11,13 @@ module OctocatalogDiff
         server_opts = options.dup
         server_opts[:rsa_key] ||= File.read(OctocatalogDiff::Spec.fixture_path('ssl/generated/server.key'))
         server_opts[:cert] ||= File.read(OctocatalogDiff::Spec.fixture_path('ssl/generated/server.crt'))
-        @test_server = SSLTestServer.new(server_opts)
-        @test_server.start
-        raise 'Unable to instantiate SSLTestServer' unless @test_server.port > 0
+        @test_server = nil
+        3.times do
+          @test_server = SSLTestServer.new(server_opts)
+          @test_server.start
+          break if @test_server.port > 0
+        end
+        raise OctocatalogDiff::Spec::FixtureError, 'Unable to instantiate SSLTestServer' unless @test_server.port > 0
       end
 
       def stop

--- a/spec/octocatalog-diff/integration/puppetmaster_spec.rb
+++ b/spec/octocatalog-diff/integration/puppetmaster_spec.rb
@@ -9,9 +9,13 @@ module OctocatalogDiff
         server_opts = options.dup
         server_opts[:rsa_key] ||= File.read(OctocatalogDiff::Spec.fixture_path('ssl/generated/server.key'))
         server_opts[:cert] ||= File.read(OctocatalogDiff::Spec.fixture_path('ssl/generated/server.crt'))
-        @test_server = SSLTestServer.new(server_opts)
-        @test_server.start
-        raise 'Unable to instantiate SSLTestServer' unless @test_server.port > 0
+        @test_server = nil
+        3.times do
+          @test_server = SSLTestServer.new(server_opts)
+          @test_server.start
+          break if @test_server.port > 0
+        end
+        raise OctocatalogDiff::Spec::FixtureError, 'Unable to instantiate SSLTestServer' unless @test_server.port > 0
       end
 
       def stop

--- a/spec/octocatalog-diff/support/httparty/ssl_test_server.rb
+++ b/spec/octocatalog-diff/support/httparty/ssl_test_server.rb
@@ -30,8 +30,13 @@ class SSLTestServer
 
   def stop
     if @child_pid.is_a?(Fixnum)
-      Process.kill('TERM', @child_pid)
-      Process.wait
+      begin
+        Process.kill('TERM', @child_pid)
+        Process.wait
+      rescue Errno::ESRCH
+        # If we get #<Errno::ESRCH: No such process>, then there is nothing
+        # that needs to be stopped. We don't have to fail the test if this occurs.
+      end
     end
   end
 

--- a/spec/octocatalog-diff/tests/puppetdb_spec.rb
+++ b/spec/octocatalog-diff/tests/puppetdb_spec.rb
@@ -9,9 +9,13 @@ PUPPETDB_SSL_PORT = 8081
 def ssl_test(server_opts, opts = {})
   server_opts[:rsa_key] ||= File.read(OctocatalogDiff::Spec.fixture_path('ssl/generated/server.key'))
   server_opts[:cert] ||= File.read(OctocatalogDiff::Spec.fixture_path('ssl/generated/server.crt'))
-  test_server = SSLTestServer.new(server_opts)
-  test_server.start
-  raise 'Unable to instantiate SSLTestServer' unless test_server.port > 0
+  test_server = nil
+  3.times do
+    test_server = SSLTestServer.new(server_opts)
+    test_server.start
+    break if test_server.port > 0
+  end
+  raise OctocatalogDiff::Spec::FixtureError, 'Unable to instantiate SSLTestServer' unless test_server.port > 0
   testobj = OctocatalogDiff::PuppetDB.new(opts.merge(puppetdb_url: "https://localhost:#{test_server.port}"))
   return testobj.get('/foo')
 ensure

--- a/spec/octocatalog-diff/tests/spec_helper.rb
+++ b/spec/octocatalog-diff/tests/spec_helper.rb
@@ -37,6 +37,9 @@ module OctocatalogDiff
     PUPPET_BINARY = File.expand_path('../../../script/puppet', File.dirname(__FILE__)).freeze
     raise "Puppet binary (#{PUPPET_BINARY}) is missing" unless File.file?(PUPPET_BINARY)
 
+    # An error to raise if a fixture fails but code doesn't
+    class FixtureError; end
+
     # One 'require' to rule them all. Find the code relative to the directory
     # of this spec file, so we can easily update this to reflect packaging changes.
     def self.require_path(path)


### PR DESCRIPTION
## Overview

This pull request ignores the `#<Errno::ESRCH: No such process>` exception that's being thrown on Travis CI, during the portion of the test that is attempting to kill that process. If the process is already dead, it's fine if we can't kill it.

It also adds a retry around starting the SSL server for some of the integration tests, so that a failure to start the test server has less of a change of failing the job. This seems to be an issue specific to Travis CI and it's intermittent.

## Checklist

- [x] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.