### PR TITLE
hiera_yaml_file -> hiera_config everywhere

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -30,7 +30,7 @@
 
   To be minimally functional, you will almost certainly need to define at least the following settings:
 
-  - `settings[:hiera_yaml_file]` as the absolute or relative path to your hiera configuration file
+  - `settings[:hiera_config]` as the absolute or relative path to your hiera configuration file
   - `settings[:hiera_path_strip]` as the prefix to strip when munging the hiera configuration file
   - `settings[:puppetdb_url]` as the URL to your PuppetDB instance so facts can be obtained
 

--- a/examples/octocatalog-diff.cfg.rb
+++ b/examples/octocatalog-diff.cfg.rb
@@ -26,15 +26,15 @@ module OctocatalogDiff
       settings = {}
 
       ##############################################################################################
-      # hiera_yaml_file
+      # hiera_config
       #   Path to the hiera.yaml configuration file. If the path starts with a `/`, then it is
       #   treated as an absolute path on this system. Otherwise, the path will be treated as
       #   a relative path. If you don't specify this, the tool will assume you aren't using Hiera.
       #   More: https://github.com/github/octocatalog-diff/blob/master/doc/configuration-hiera.md
       ##############################################################################################
 
-      # settings[:hiera_yaml_file] = '/etc/puppetlabs/puppet/hiera.yaml' # Absolute path
-      # settings[:hiera_yaml_file] = 'environments/production/config/hiera.yaml' # Relative path
+      # settings[:hiera_config] = '/etc/puppetlabs/puppet/hiera.yaml' # Absolute path
+      # settings[:hiera_config] = 'environments/production/config/hiera.yaml' # Relative path
 
       ##############################################################################################
       # hiera_path_strip


### PR DESCRIPTION
This pull request fixes the documentation and example config file.

`settings[:hiera_yaml_file]` is not correct. The correct setting is `settings[:hiera_config]`.

Fixes https://github.com/github/octocatalog-diff/issues/13

Thanks to @eelcomaljaars for the report.