### PR TITLE
Add notes about trailing slashes for --hiera-path-strip

### DIFF
--- a/doc/advanced-hiera-path-stripping.md
+++ b/doc/advanced-hiera-path-stripping.md
@@ -37,3 +37,5 @@ bin/octocatalog-diff --hiera-config hiera.yaml --hiera-path-strip /etc/puppetlab
 :yaml:
   :datadir: /var/tmp/puppet-compile-dir-92347829847/environments/%{environment}/hieradata
 ```
+
+:warning: Be sure that you do NOT include a trailing slash on `--hiera-path-strip` or `settings[:hiera_path_strip]`.

--- a/examples/octocatalog-diff.cfg.rb
+++ b/examples/octocatalog-diff.cfg.rb
@@ -56,6 +56,7 @@ module OctocatalogDiff
       #      In this case, you desire to strip `/etc/puppetlabs/code` from the beginning of the path,
       #      in order that octocatalog-diff can find your hiera datafiles in the compilation
       #      location, which is {temporary directory}/environments/production/hieradata.
+      #      If you use this, be sure that you do NOT include a trailing slash!
       #
       #      More: https://github.com/github/octocatalog-diff/blob/master/doc/configuration-hiera.md
       ##############################################################################################


### PR DESCRIPTION
## Overview

Documentation and example update which adds a reminder not to include a trailing slash on `--hiera-path-strip`.

Fixes https://github.com/github/octocatalog-diff/issues/23