### PR TITLE
Allow bootstrap script to start with slash

### DIFF
--- a/lib/octocatalog-diff/catalog-util/bootstrap.rb
+++ b/lib/octocatalog-diff/catalog-util/bootstrap.rb
@@ -116,7 +116,11 @@ module OctocatalogDiff
       # @param opts [Hash] Directory options
       def self.install_bootstrap_script(logger, opts)
         # Verify that bootstrap file exists
-        src = File.join(opts[:basedir], opts[:bootstrap_script])
+        src = if opts[:bootstrap_script].start_with? '/'
+          opts[:bootstrap_script]
+        else
+          File.join(opts[:basedir], opts[:bootstrap_script])
+        end
         raise BootstrapError, "Bootstrap script #{src} does not exist" unless File.file?(src)
 
         logger.debug('Begin install bootstrap script in target directory')

--- a/spec/octocatalog-diff/tests/catalog-util/bootstrap_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-util/bootstrap_spec.rb
@@ -145,6 +145,22 @@ describe OctocatalogDiff::CatalogUtil::Bootstrap do
         expect(File.file?(File.join(@dir, 'bootstrap_result.yaml'))).to eq(true)
         expect(File.file?(File.join(@dir2, 'bootstrap_result.yaml'))).to eq(true)
       end
+
+      it 'should run a bootstrap script specified as an absolute path' do
+        logger, _logger_str = OctocatalogDiff::Spec.setup_logger
+        opts = {
+          bootstrapped_to_dir: @dir,
+          bootstrapped_from_dir: @dir2,
+          to_env: 'test-branch',
+          from_env: 'master',
+          basedir: File.join(@repo_dir, 'git-repo'),
+          parallel: false,
+          bootstrap_script: File.join(@repo_dir, 'git-repo', 'script', 'bootstrap.sh')
+        }
+        OctocatalogDiff::CatalogUtil::Bootstrap.bootstrap_directory_parallelizer(opts, logger)
+        expect(File.file?(File.join(@dir, 'bootstrap_result.yaml'))).to eq(true)
+        expect(File.file?(File.join(@dir2, 'bootstrap_result.yaml'))).to eq(true)
+      end
     end
   end
 end


### PR DESCRIPTION
## Overview

This pull request treats the user-supplied bootstrap script as an absolute path when it starts with `/`.

See https://github.com/github/octocatalog-diff/issues/28 for context.

Fixes https://github.com/github/octocatalog-diff/issues/28.
