### PR TITLE
Make hiera configuration work for alternate environments too

### DIFF
--- a/spec/octocatalog-diff/fixtures/repos/preserve-environments/environments/one/hiera.yaml
+++ b/spec/octocatalog-diff/fixtures/repos/preserve-environments/environments/one/hiera.yaml
@@ -1,0 +1,9 @@
+---
+:backends:
+  - yaml
+:yaml:
+  :datadir: /var/lib/puppet/environments/%{::environment}/hieradata
+:hierarchy:
+  - common
+:merge_behavior: deeper
+:logger: console

--- a/spec/octocatalog-diff/fixtures/repos/preserve-environments/environments/one/hieradata/common.yaml
+++ b/spec/octocatalog-diff/fixtures/repos/preserve-environments/environments/one/hieradata/common.yaml
@@ -1,0 +1,2 @@
+---
+  bar::param: 'Value from one/hieradata/common.yaml'

--- a/spec/octocatalog-diff/fixtures/repos/preserve-environments/environments/one/modules/bar/manifests/init.pp
+++ b/spec/octocatalog-diff/fixtures/repos/preserve-environments/environments/one/modules/bar/manifests/init.pp
@@ -1,4 +1,6 @@
-class bar {
+class bar (
+  $param = '',
+) {
   include sitetest
 
   file { '/tmp/bar':
@@ -8,5 +10,9 @@ class bar {
 
   file { '/tmp/bar-static.txt':
     source => 'puppet:///modules/bar/bar-static.txt',
+  }
+
+  file { '/tmp/bar-param.txt':
+    content => "one ${param}",
   }
 }

--- a/spec/octocatalog-diff/fixtures/repos/preserve-environments/environments/two/hiera.yaml
+++ b/spec/octocatalog-diff/fixtures/repos/preserve-environments/environments/two/hiera.yaml
@@ -1,0 +1,9 @@
+---
+:backends:
+  - yaml
+:yaml:
+  :datadir: /var/lib/puppet/environments/%{::environment}/hieradata
+:hierarchy:
+  - common
+:merge_behavior: deeper
+:logger: console

--- a/spec/octocatalog-diff/fixtures/repos/preserve-environments/environments/two/hieradata/common.yaml
+++ b/spec/octocatalog-diff/fixtures/repos/preserve-environments/environments/two/hieradata/common.yaml
@@ -1,0 +1,2 @@
+---
+  bar::param: 'Value from two/hieradata/common.yaml'

--- a/spec/octocatalog-diff/fixtures/repos/preserve-environments/environments/two/modules/bar/manifests/init.pp
+++ b/spec/octocatalog-diff/fixtures/repos/preserve-environments/environments/two/modules/bar/manifests/init.pp
@@ -1,4 +1,6 @@
-class bar {
+class bar (
+  $param = '',
+) {
   include sitetest
 
   file { '/tmp/bar':
@@ -8,5 +10,9 @@ class bar {
 
   file { '/tmp/bar-static.txt':
     source => 'puppet:///modules/bar/bar-static.txt',
+  }
+
+  file { '/tmp/bar-param.txt':
+    content => "two ${param}",
   }
 }

--- a/spec/octocatalog-diff/integration/preserve_environments_spec.rb
+++ b/spec/octocatalog-diff/integration/preserve_environments_spec.rb
@@ -137,7 +137,9 @@ describe 'preserve environments integration' do
               '--preserve-environments',
               '--from-environment', 'one',
               '--to-environment', 'two',
-              '--create-symlinks', 'modules,site'
+              '--create-symlinks', 'modules,site',
+              '--hiera-config', 'hiera.yaml',
+              '--hiera-path-strip', '/var/lib/puppet'
             ]
           )
         end
@@ -145,6 +147,7 @@ describe 'preserve environments integration' do
         it 'should exit without error' do
           expect(@result.exitcode).to eq(2), OctocatalogDiff::Integration.format_exception(@result)
           expect(@result.exception).to be_nil, OctocatalogDiff::Integration.format_exception(@result)
+          expect(@result.diffs.any?).to eq(true), OctocatalogDiff::Integration.format_exception(@result)
         end
 
         it 'should display proper diffs' do
@@ -177,6 +180,13 @@ describe 'preserve environments integration' do
               ['~', "File\f/tmp/sitetest\fparameters\fcontent", 'one', 'two']
             )
           ).to eq(true)
+        end
+
+        it 'should handle hieradata properly' do
+          h = @result.diffs.select { |x| x[1] == "File\f/tmp/bar-param.txt\fparameters\fcontent" }
+          expect(h.size).to eq(1), h.inspect
+          expect(h.first[2]).to eq('one Value from one/hieradata/common.yaml')
+          expect(h.first[3]).to eq('two Value from two/hieradata/common.yaml')
         end
       end
 


### PR DESCRIPTION
Fixes the problem in https://github.com/github/octocatalog-diff/issues/35#issuecomment-270070454

/cc @tobias-urdin - The fix was actually pretty easy (https://github.com/github/octocatalog-diff/commit/e3531b38c08e0b4a281ff0f7d1b6b9a8dd0f332f) and then I added a bunch of testing around it. Could you try this branch and see if the issue you reported is fixed?