### PR TITLE
Move cli/catalogs -> util/catalogs

### DIFF
--- a/lib/octocatalog-diff/catalog-util/bootstrap.rb
+++ b/lib/octocatalog-diff/catalog-util/bootstrap.rb
@@ -84,7 +84,7 @@ module OctocatalogDiff
       end
 
       # Performs the actual bootstrap of a directory. Intended to be called by bootstrap_directory_parallelizer
-      # above, or as part of the parallelized catalog build process from cli/catalogs.
+      # above, or as part of the parallelized catalog build process from util/catalogs.
       # @param logger [Logger] Logger object
       # @param dir_opts [Hash] Directory options: branch, path, tag
       def self.bootstrap_directory(options, logger)

--- a/lib/octocatalog-diff/catalog-util/cached_master_directory.rb
+++ b/lib/octocatalog-diff/catalog-util/cached_master_directory.rb
@@ -2,7 +2,7 @@
 
 require_relative 'bootstrap'
 require_relative 'git'
-require_relative '../cli/catalogs'
+require_relative '../util/catalogs'
 
 require 'fileutils'
 
@@ -134,7 +134,7 @@ module OctocatalogDiff
         fake_options[:from_env] = master_branch(options)
 
         logger.debug 'Begin bootstrap cached master directory'
-        catalogs_obj = OctocatalogDiff::Cli::Catalogs.new(fake_options, logger)
+        catalogs_obj = OctocatalogDiff::Util::Catalogs.new(fake_options, logger)
         catalogs_obj.bootstrap_then_exit
         logger.debug 'Success bootstrap cached master directory'
 

--- a/lib/octocatalog-diff/cli.rb
+++ b/lib/octocatalog-diff/cli.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'cli/catalogs'
+require_relative 'util/catalogs'
 require_relative 'cli/diffs'
 require_relative 'cli/helpers/fact_override'
 require_relative 'cli/options'
@@ -101,7 +101,7 @@ module OctocatalogDiff
       # depend on facts. This happens within the 'catalogs' object, since bootstrapping and
       # preparing catalogs are tightly coupled operations. However this does not actually
       # build catalogs.
-      catalogs_obj = OctocatalogDiff::Cli::Catalogs.new(options, logger)
+      catalogs_obj = OctocatalogDiff::Util::Catalogs.new(options, logger)
       return bootstrap_then_exit(logger, catalogs_obj) if options[:bootstrap_then_exit]
 
       # Compile catalogs
@@ -181,7 +181,7 @@ module OctocatalogDiff
         from_catalog: '-', # Prevents a compile
         to_catalog: nil, # Forces a compile
       )
-      cat_obj = OctocatalogDiff::Cli::Catalogs.new(catalog_opts, logger)
+      cat_obj = OctocatalogDiff::Util::Catalogs.new(catalog_opts, logger)
       catalogs = cat_obj.catalogs
 
       # If the catalog compilation failed, an exception would have been thrown. So if
@@ -201,7 +201,7 @@ module OctocatalogDiff
     def self.bootstrap_then_exit(logger, catalogs_obj)
       catalogs_obj.bootstrap_then_exit
       return EXITCODE_SUCCESS_NO_DIFFS
-    rescue OctocatalogDiff::Cli::Catalogs::BootstrapError => exc
+    rescue OctocatalogDiff::Util::Catalogs::BootstrapError => exc
       logger.fatal("--bootstrap-then-exit error: bootstrap failed (#{exc})")
       return EXITCODE_FAILURE
     end

--- a/lib/octocatalog-diff/util/catalogs.rb
+++ b/lib/octocatalog-diff/util/catalogs.rb
@@ -5,10 +5,10 @@ require 'open3'
 require 'yaml'
 require_relative '../catalog-util/bootstrap' # For BootstrapError
 require_relative '../catalog'
-require_relative '../util/parallel'
+require_relative 'parallel'
 
 module OctocatalogDiff
-  class Cli
+  module Util
     # Helper class to construct catalogs, performing all necessary steps such as
     # bootstrapping directories, installing facts, and running puppet.
     class Catalogs

--- a/spec/octocatalog-diff/integration/catalog_compute_spec.rb
+++ b/spec/octocatalog-diff/integration/catalog_compute_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative 'integration_helper'
 
-require OctocatalogDiff::Spec.require_path('/cli/catalogs')
+require OctocatalogDiff::Spec.require_path('/util/catalogs')
 require OctocatalogDiff::Spec.require_path('/catalog')
 require OctocatalogDiff::Spec.require_path('/facts')
 
@@ -48,7 +48,7 @@ describe 'computing catalog without hiera and with ENC' do
         if @has_git && @has_tar && @has_bash
           options = @default_options.merge(enc: 'environments/production/config/enc.sh')
           logger, _logger_string = OctocatalogDiff::Spec.setup_logger
-          testobj = OctocatalogDiff::Cli::Catalogs.new(options, logger)
+          testobj = OctocatalogDiff::Util::Catalogs.new(options, logger)
           result = testobj.catalogs
           @to = result[:to]
           @from = result[:from]
@@ -111,7 +111,7 @@ describe 'computing catalog without hiera and with ENC' do
         if @has_git && @has_tar
           options = @default_options.dup
           logger, _logger_string = OctocatalogDiff::Spec.setup_logger
-          testobj = OctocatalogDiff::Cli::Catalogs.new(options, logger)
+          testobj = OctocatalogDiff::Util::Catalogs.new(options, logger)
           result = testobj.catalogs
           @to = result[:to]
           @from = result[:from]
@@ -175,7 +175,7 @@ describe 'computing catalog without hiera and with ENC' do
           options = @default_options.merge(hiera_config: 'environments/production/config/hiera.yaml',
                                            hiera_path_strip: '/var/lib/puppet')
           logger, _logger_string = OctocatalogDiff::Spec.setup_logger
-          testobj = OctocatalogDiff::Cli::Catalogs.new(options, logger)
+          testobj = OctocatalogDiff::Util::Catalogs.new(options, logger)
           result = testobj.catalogs
           @to = result[:to]
           @from = result[:from]
@@ -257,7 +257,7 @@ describe 'computing catalog without hiera and with ENC' do
             to_env: '.'
           )
           logger, _logger_string = OctocatalogDiff::Spec.setup_logger
-          testobj = OctocatalogDiff::Cli::Catalogs.new(options, logger)
+          testobj = OctocatalogDiff::Util::Catalogs.new(options, logger)
           result = testobj.catalogs
           @to = result[:to]
           @from = result[:from]

--- a/spec/octocatalog-diff/integration/convert_file_resources_spec.rb
+++ b/spec/octocatalog-diff/integration/convert_file_resources_spec.rb
@@ -118,7 +118,7 @@ describe 'convert file resources' do
         ]
       )
       expect(result[:exitcode]).to eq(-1)
-      expect(result[:exception]).to be_a_kind_of(OctocatalogDiff::Cli::Catalogs::CatalogError)
+      expect(result[:exception]).to be_a_kind_of(OctocatalogDiff::Util::Catalogs::CatalogError)
       expect(result[:exception].message).to match(/failed to compile with Errno::ENOENT/)
       expect(result[:exception].message).to match(%r{Unable to resolve 'puppet:///modules/test/foo-new'})
     end

--- a/spec/octocatalog-diff/integration/pe_enc_spec.rb
+++ b/spec/octocatalog-diff/integration/pe_enc_spec.rb
@@ -129,7 +129,7 @@ describe 'with an actual Puppet Enterprise ENC and SSL client auth' do
     }
     result = OctocatalogDiff::Integration.integration(opts)
     expect(result[:exitcode]).to eq(-1)
-    expect(result[:exception].class.to_s).to eq('OctocatalogDiff::Cli::Catalogs::CatalogError')
+    expect(result[:exception].class.to_s).to eq('OctocatalogDiff::Util::Catalogs::CatalogError')
     expect(result[:exception].message).to match(/OpenSSL::SSL::SSLError/)
   end
 
@@ -194,7 +194,7 @@ describe 'with an actual Puppet Enterprise ENC and token auth' do
     }
     result = OctocatalogDiff::Integration.integration(opts)
     expect(result[:exitcode]).to eq(-1)
-    expect(result[:exception].class.to_s).to eq('OctocatalogDiff::Cli::Catalogs::CatalogError')
+    expect(result[:exception].class.to_s).to eq('OctocatalogDiff::Util::Catalogs::CatalogError')
     expect(result[:exception].message).to match(/Failed ENC: Response from https:.+rspec-node.xyz.github.net was 403/)
   end
 
@@ -212,7 +212,7 @@ describe 'with an actual Puppet Enterprise ENC and token auth' do
     }
     result = OctocatalogDiff::Integration.integration(opts)
     expect(result[:exitcode]).to eq(-1)
-    expect(result[:exception].class.to_s).to eq('OctocatalogDiff::Cli::Catalogs::CatalogError')
+    expect(result[:exception].class.to_s).to eq('OctocatalogDiff::Util::Catalogs::CatalogError')
     expect(result[:exception].message).to match(/Failed ENC: Response from https:.+rspec-node.xyz.github.net was 403/)
   end
 

--- a/spec/octocatalog-diff/integration/preserve_environments_spec.rb
+++ b/spec/octocatalog-diff/integration/preserve_environments_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative 'integration_helper'
 
-OctocatalogDiff::Spec.require_path('/cli/catalogs')
+OctocatalogDiff::Spec.require_path('/util/catalogs')
 
 describe 'preserve environments integration' do
   context 'without --preserve-environments set' do
@@ -22,8 +22,8 @@ describe 'preserve environments integration' do
         expect(@result.exitcode).to eq(-1), OctocatalogDiff::Integration.format_exception(@result)
       end
 
-      it 'should raise OctocatalogDiff::Cli::Catalogs::CatalogError' do
-        expect(@result.exception).to be_a_kind_of(OctocatalogDiff::Cli::Catalogs::CatalogError)
+      it 'should raise OctocatalogDiff::Util::Catalogs::CatalogError' do
+        expect(@result.exception).to be_a_kind_of(OctocatalogDiff::Util::Catalogs::CatalogError)
       end
 
       it 'should fail because ::bar could not be located' do
@@ -98,7 +98,7 @@ describe 'preserve environments integration' do
 
       it 'should exit with error status due modules in production environment not being found' do
         expect(@result.exitcode).to eq(-1), OctocatalogDiff::Integration.format_exception(@result)
-        expect(@result.exception).to be_a_kind_of(OctocatalogDiff::Cli::Catalogs::CatalogError)
+        expect(@result.exception).to be_a_kind_of(OctocatalogDiff::Util::Catalogs::CatalogError)
         expect(@result.exception.message).to match(/Errno::ENOENT: No such file or directory - Environment directory/)
       end
     end
@@ -121,7 +121,7 @@ describe 'preserve environments integration' do
 
       it 'should error on missing environment' do
         expect(@result.exitcode).to eq(-1), OctocatalogDiff::Integration.format_exception(@result)
-        expect(@result.exception).to be_a_kind_of(OctocatalogDiff::Cli::Catalogs::CatalogError)
+        expect(@result.exception).to be_a_kind_of(OctocatalogDiff::Util::Catalogs::CatalogError)
         expect(@result.exception.message).to match(%r{Environment directory .+/environments/fluffy does not exist})
       end
     end
@@ -208,7 +208,7 @@ describe 'preserve environments integration' do
 
         it 'should error on missing site directory' do
           expect(@result.exitcode).to eq(-1), OctocatalogDiff::Integration.format_exception(@result)
-          expect(@result.exception).to be_a_kind_of(OctocatalogDiff::Cli::Catalogs::CatalogError)
+          expect(@result.exception).to be_a_kind_of(OctocatalogDiff::Util::Catalogs::CatalogError)
           expect(@result.exception.message).to match(/Could not find class (::)?sitetest/)
         end
       end
@@ -231,7 +231,7 @@ describe 'preserve environments integration' do
 
         it 'should error on missing module' do
           expect(@result.exitcode).to eq(-1), OctocatalogDiff::Integration.format_exception(@result)
-          expect(@result.exception).to be_a_kind_of(OctocatalogDiff::Cli::Catalogs::CatalogError)
+          expect(@result.exception).to be_a_kind_of(OctocatalogDiff::Util::Catalogs::CatalogError)
           expect(@result.exception.message).to match(/Could not find class (::)?foo/)
         end
       end
@@ -254,7 +254,7 @@ describe 'preserve environments integration' do
 
         it 'should raise exception due to missing symlink request' do
           expect(@result.exitcode).to eq(-1), OctocatalogDiff::Integration.format_exception(@result)
-          expect(@result.exception).to be_a_kind_of(OctocatalogDiff::Cli::Catalogs::CatalogError)
+          expect(@result.exception).to be_a_kind_of(OctocatalogDiff::Util::Catalogs::CatalogError)
           expect(@result.exception.message).to match(%r{Catalog for 'from' \(origin/master\) failed.+ Errno::ENOENT})
           expect(@result.exception.message).to match(%r{Specified directory .+/preserve-environments/fluffy doesn't exist})
         end
@@ -303,7 +303,7 @@ describe 'preserve environments integration' do
 
         it 'should error on missing site directory' do
           expect(@result.exitcode).to eq(-1), OctocatalogDiff::Integration.format_exception(@result)
-          expect(@result.exception).to be_a_kind_of(OctocatalogDiff::Cli::Catalogs::CatalogError)
+          expect(@result.exception).to be_a_kind_of(OctocatalogDiff::Util::Catalogs::CatalogError)
           expect(@result.exception.message).to match(/Could not find class (::)?sitetest/)
         end
       end
@@ -326,7 +326,7 @@ describe 'preserve environments integration' do
 
       it 'should error on missing site directory' do
         expect(@result.exitcode).to eq(-1), OctocatalogDiff::Integration.format_exception(@result)
-        expect(@result.exception).to be_a_kind_of(OctocatalogDiff::Cli::Catalogs::CatalogError)
+        expect(@result.exception).to be_a_kind_of(OctocatalogDiff::Util::Catalogs::CatalogError)
         expect(@result.exception.message).to match(/Could not find class (::)?sitetest/)
       end
     end

--- a/spec/octocatalog-diff/integration/puppetdb_spec.rb
+++ b/spec/octocatalog-diff/integration/puppetdb_spec.rb
@@ -22,7 +22,7 @@ describe 'puppetdb general tests' do
     opts = { argv: ['-n', 'not-found-node.github.net'], spec_repo: 'tiny-repo' }
     result = OctocatalogDiff::Integration.integration_with_puppetdb(s_opts, opts)
     expect(result[:exitcode]).to eq(-1), OctocatalogDiff::Integration.format_exception(result)
-    expect(result[:exception].class.to_s).to eq('OctocatalogDiff::Cli::Catalogs::CatalogError')
+    expect(result[:exception].class.to_s).to eq('OctocatalogDiff::Util::Catalogs::CatalogError')
     expect(result[:exception].message).to match(/FactRetrievalError: Node not-found-node.github.net not found in PuppetDB/)
   end
 end
@@ -53,7 +53,7 @@ describe 'puppetdb ssl' do
       opts = { argv: args, spec_repo: 'tiny-repo' }
       result = OctocatalogDiff::Integration.integration_with_puppetdb(s_opts, opts)
       expect(result[:exitcode]).to eq(-1), OctocatalogDiff::Integration.format_exception(result)
-      expect(result[:exception].class.to_s).to eq('OctocatalogDiff::Cli::Catalogs::CatalogError')
+      expect(result[:exception].class.to_s).to eq('OctocatalogDiff::Util::Catalogs::CatalogError')
       expect(result[:exception].message).to match(/OpenSSL::SSL::SSLError/)
     end
 
@@ -71,7 +71,7 @@ describe 'puppetdb ssl' do
       opts = { argv: args, spec_repo: 'tiny-repo' }
       result = OctocatalogDiff::Integration.integration_with_puppetdb(s_opts, opts)
       expect(result[:exitcode]).to eq(-1), OctocatalogDiff::Integration.format_exception(result)
-      expect(result[:exception].class.to_s).to eq('OctocatalogDiff::Cli::Catalogs::CatalogError')
+      expect(result[:exception].class.to_s).to eq('OctocatalogDiff::Util::Catalogs::CatalogError')
       expect(result[:exception].message).to match(/OpenSSL::SSL::SSLError/)
     end
   end
@@ -88,7 +88,7 @@ describe 'puppetdb ssl' do
     it 'should fail to connect to authenticated puppetdb with no client cert', retry: 3 do
       opts = { argv: ['-n', 'rspec-node.github.net'], spec_repo: 'tiny-repo' }
       result = OctocatalogDiff::Integration.integration_with_puppetdb(s_opts, opts)
-      expect(result[:exception].class.to_s).to eq('OctocatalogDiff::Cli::Catalogs::CatalogError')
+      expect(result[:exception].class.to_s).to eq('OctocatalogDiff::Util::Catalogs::CatalogError')
       expect(result[:exception].message).to match(/OpenSSL::SSL::SSLError/)
     end
 
@@ -127,7 +127,7 @@ describe 'puppetdb ssl' do
       opts = { argv: arg, spec_repo: 'tiny-repo' }
       result = OctocatalogDiff::Integration.integration_with_puppetdb(s_opts, opts)
       expect(result[:exitcode]).to eq(-1), OctocatalogDiff::Integration.format_exception(result)
-      expect(result[:exception].class.to_s).to eq('OctocatalogDiff::Cli::Catalogs::CatalogError')
+      expect(result[:exception].class.to_s).to eq('OctocatalogDiff::Util::Catalogs::CatalogError')
       expect(result[:exception].message).to match(/OpenSSL::PKey::RSAError/)
     end
 
@@ -140,7 +140,7 @@ describe 'puppetdb ssl' do
       opts = { argv: arg, spec_repo: 'tiny-repo' }
       result = OctocatalogDiff::Integration.integration_with_puppetdb(s_opts, opts)
       expect(result[:exitcode]).to eq(-1), OctocatalogDiff::Integration.format_exception(result)
-      expect(result[:exception].class.to_s).to eq('OctocatalogDiff::Cli::Catalogs::CatalogError')
+      expect(result[:exception].class.to_s).to eq('OctocatalogDiff::Util::Catalogs::CatalogError')
       expect(result[:exception].message).to match(/OpenSSL::PKey::RSAError/)
     end
   end

--- a/spec/octocatalog-diff/integration/puppetmaster_spec.rb
+++ b/spec/octocatalog-diff/integration/puppetmaster_spec.rb
@@ -157,7 +157,7 @@ context 'APIv3' do
       }
       result = OctocatalogDiff::Integration.integration(opts)
       expect(result[:exitcode]).to eq(-1)
-      expect(result[:exception].class.to_s).to eq('OctocatalogDiff::Cli::Catalogs::CatalogError')
+      expect(result[:exception].class.to_s).to eq('OctocatalogDiff::Util::Catalogs::CatalogError')
       expect(result[:exception].message).to match(/OpenSSL::SSL::SSLError/)
     end
 
@@ -174,7 +174,7 @@ context 'APIv3' do
       }
       result = OctocatalogDiff::Integration.integration(opts)
       expect(result[:exitcode]).to eq(-1)
-      expect(result[:exception].class.to_s).to eq('OctocatalogDiff::Cli::Catalogs::CatalogError')
+      expect(result[:exception].class.to_s).to eq('OctocatalogDiff::Util::Catalogs::CatalogError')
       expect(result[:exception].message).to match(/foobaz.local: 404/)
     end
 

--- a/spec/octocatalog-diff/tests/cli_spec.rb
+++ b/spec/octocatalog-diff/tests/cli_spec.rb
@@ -197,8 +197,8 @@ describe OctocatalogDiff::Cli do
       before(:each) do
         catalog_json = File.read(OctocatalogDiff::Spec.fixture_path('catalogs/tiny-catalog.json'))
         catalogs = { to: OctocatalogDiff::Catalog.new(json: catalog_json) }
-        d = double('OctocatalogDiff::Cli::Catalogs')
-        allow(OctocatalogDiff::Cli::Catalogs).to receive(:new).and_return(d)
+        d = double('OctocatalogDiff::Util::Catalogs')
+        allow(OctocatalogDiff::Util::Catalogs).to receive(:new).and_return(d)
         allow(d).to receive(:catalogs).and_return(catalogs)
         logger, @logger_str = OctocatalogDiff::Spec.setup_logger
         @tmpdir = Dir.mktmpdir
@@ -222,8 +222,8 @@ describe OctocatalogDiff::Cli do
       it 'should output to STDOUT and exit' do
         catalog_json = File.read(OctocatalogDiff::Spec.fixture_path('catalogs/tiny-catalog.json'))
         catalogs = { to: OctocatalogDiff::Catalog.new(json: catalog_json) }
-        d = double('OctocatalogDiff::Cli::Catalogs')
-        allow(OctocatalogDiff::Cli::Catalogs).to receive(:new).and_return(d)
+        d = double('OctocatalogDiff::Util::Catalogs')
+        allow(OctocatalogDiff::Util::Catalogs).to receive(:new).and_return(d)
         allow(d).to receive(:catalogs).and_return(catalogs)
         logger, logger_str = OctocatalogDiff::Spec.setup_logger
         rexp = Regexp.new('"document_type": "Catalog"')
@@ -236,7 +236,7 @@ describe OctocatalogDiff::Cli do
 
   describe '#bootstrap_then_exit' do
     it 'should succeed and exit 0' do
-      d = double('OctocatalogDiff::Cli::Catalogs')
+      d = double('OctocatalogDiff::Util::Catalogs')
       allow(d).to receive(:bootstrap_then_exit)
       logger, logger_str = OctocatalogDiff::Spec.setup_logger
       rc = OctocatalogDiff::Cli.bootstrap_then_exit(logger, d)
@@ -245,8 +245,8 @@ describe OctocatalogDiff::Cli do
     end
 
     it 'should fail and exit 1 if BootstrapError occurs' do
-      d = double('OctocatalogDiff::Cli::Catalogs')
-      allow(d).to receive(:bootstrap_then_exit).and_raise(OctocatalogDiff::Cli::Catalogs::BootstrapError, 'hello')
+      d = double('OctocatalogDiff::Util::Catalogs')
+      allow(d).to receive(:bootstrap_then_exit).and_raise(OctocatalogDiff::Util::Catalogs::BootstrapError, 'hello')
       logger, logger_str = OctocatalogDiff::Spec.setup_logger
       rc = OctocatalogDiff::Cli.bootstrap_then_exit(logger, d)
       expect(rc).to eq(1)

--- a/spec/octocatalog-diff/tests/util/catalogs_spec.rb
+++ b/spec/octocatalog-diff/tests/util/catalogs_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative '../spec_helper'
 require_relative '../../mocks/puppetdb'
-require OctocatalogDiff::Spec.require_path('/cli/catalogs')
+require OctocatalogDiff::Spec.require_path('/util/catalogs')
 require OctocatalogDiff::Spec.require_path('/catalog')
 require OctocatalogDiff::Spec.require_path('/facts')
 
@@ -33,7 +33,7 @@ class BadCatalog
 end
 
 # Here begin the tests
-describe OctocatalogDiff::Cli::Catalogs do
+describe OctocatalogDiff::Util::Catalogs do
   before(:all) do
     # These are the default options for all tests.
     @default_options = {
@@ -90,8 +90,8 @@ describe OctocatalogDiff::Cli::Catalogs do
     it 'should error when neither directory is specified' do
       options = @default_options.merge(from_env: 'master')
       logger, logger_string = OctocatalogDiff::Spec.setup_logger
-      testobj = OctocatalogDiff::Cli::Catalogs.new(options, logger)
-      expect { testobj.bootstrap_then_exit }.to raise_error(OctocatalogDiff::Cli::Catalogs::BootstrapError)
+      testobj = OctocatalogDiff::Util::Catalogs.new(options, logger)
+      expect { testobj.bootstrap_then_exit }.to raise_error(OctocatalogDiff::Util::Catalogs::BootstrapError)
       expect(logger_string.string).to match(%r{Specify one or more of --bootstrapped-from-dir / --bootstrapped-to-dir})
     end
 
@@ -103,8 +103,8 @@ describe OctocatalogDiff::Cli::Catalogs do
         tmpdir2 = Dir.mktmpdir
         options = @default_options.merge(basedir: tmpdir2, bootstrapped_from_dir: tmpdir1, from_env: 'asdfasdfasdf')
         logger, logger_string = OctocatalogDiff::Spec.setup_logger
-        testobj = OctocatalogDiff::Cli::Catalogs.new(options, logger)
-        expect { testobj.bootstrap_then_exit }.to raise_error(OctocatalogDiff::Cli::Catalogs::BootstrapError)
+        testobj = OctocatalogDiff::Util::Catalogs.new(options, logger)
+        expect { testobj.bootstrap_then_exit }.to raise_error(OctocatalogDiff::Util::Catalogs::BootstrapError)
         expect(logger_string.string).to match(/ERROR -- : Bootstrap exception: Failed bootstrap_directory for from_dir/)
       ensure
         OctocatalogDiff::Spec.clean_up_tmpdir(tmpdir1)
@@ -119,8 +119,8 @@ describe OctocatalogDiff::Cli::Catalogs do
         tmpdir1 = Dir.mktmpdir
         options = @default_options.merge(bootstrapped_from_dir: tmpdir1, from_env: 'asdfasdfasdf')
         logger, logger_string = OctocatalogDiff::Spec.setup_logger
-        testobj = OctocatalogDiff::Cli::Catalogs.new(options, logger)
-        expect { testobj.bootstrap_then_exit }.to raise_error(OctocatalogDiff::Cli::Catalogs::BootstrapError)
+        testobj = OctocatalogDiff::Util::Catalogs.new(options, logger)
+        expect { testobj.bootstrap_then_exit }.to raise_error(OctocatalogDiff::Util::Catalogs::BootstrapError)
         expect(logger_string.string).to match(/ERROR -- : Bootstrap exception: Failed bootstrap_directory for from_dir/)
       ensure
         OctocatalogDiff::Spec.clean_up_tmpdir(tmpdir1)
@@ -136,13 +136,13 @@ describe OctocatalogDiff::Cli::Catalogs do
                                            bootstrapped_from_dir: @dir1,
                                            bootstrapped_to_dir: @dir2)
           logger, logger_string = OctocatalogDiff::Spec.setup_logger
-          testobj = OctocatalogDiff::Cli::Catalogs.new(options, logger)
+          testobj = OctocatalogDiff::Util::Catalogs.new(options, logger)
           path_save = ENV['PATH']
           begin
             @bootstrap_error_message = nil
             ENV['PATH'] = '/usr/sbin:/sbin:/usr/bin:/bin:/usr/local/bin:/usr/local/sbin'
             testobj.bootstrap_then_exit
-          rescue OctocatalogDiff::Cli::Catalogs::BootstrapError => exc
+          rescue OctocatalogDiff::Util::Catalogs::BootstrapError => exc
             @bootstrap_error_message = "BootstrapError #{exc}: #{logger_string.string}"
           ensure
             ENV['PATH'] = path_save
@@ -194,9 +194,9 @@ describe OctocatalogDiff::Cli::Catalogs do
         pending 'bash, git, and/or tar are required for most tests' unless @has_tar
         options = @default_options.merge(enc: 'asdkfjlfjkalksdfads')
         logger, _logger_string = OctocatalogDiff::Spec.setup_logger
-        testobj = OctocatalogDiff::Cli::Catalogs.new(options, logger)
+        testobj = OctocatalogDiff::Util::Catalogs.new(options, logger)
         re = %r{ENC.*/asdkfjlfjkalksdfads wasn't found}
-        expect { testobj.catalogs }.to raise_error(OctocatalogDiff::Cli::Catalogs::CatalogError, re)
+        expect { testobj.catalogs }.to raise_error(OctocatalogDiff::Util::Catalogs::CatalogError, re)
       end
     end
   end
@@ -207,9 +207,9 @@ describe OctocatalogDiff::Cli::Catalogs do
         pending 'bash, git, and/or tar are required for most tests' unless @has_tar
         options = @default_options.merge(hiera_config: 'asdkfjlfjkalksdfads')
         logger, _logger_string = OctocatalogDiff::Spec.setup_logger
-        testobj = OctocatalogDiff::Cli::Catalogs.new(options, logger)
+        testobj = OctocatalogDiff::Util::Catalogs.new(options, logger)
         re = %r{hiera.yaml.*/asdkfjlfjkalksdfads\) wasn't found}
-        expect { testobj.catalogs }.to raise_error(OctocatalogDiff::Cli::Catalogs::CatalogError, re)
+        expect { testobj.catalogs }.to raise_error(OctocatalogDiff::Util::Catalogs::CatalogError, re)
       end
     end
   end
@@ -226,7 +226,7 @@ describe OctocatalogDiff::Cli::Catalogs do
           to_catalog: OctocatalogDiff::Spec.fixture_path('catalogs/tiny-catalog-2.json')
         )
         logger, logger_string = OctocatalogDiff::Spec.setup_logger
-        testobj = OctocatalogDiff::Cli::Catalogs.new(options, logger)
+        testobj = OctocatalogDiff::Util::Catalogs.new(options, logger)
         result = testobj.catalogs
 
         test_val = result[:from].catalog_json.gsub(/\s+/, '')
@@ -250,7 +250,7 @@ describe OctocatalogDiff::Cli::Catalogs do
     it 'should select noop backend if incoming catalog is a minus sign' do
       options = { from_catalog: '-', to_catalog: '-', from_branch: 'foo', to_branch: 'bar' }
       logger, logger_str = OctocatalogDiff::Spec.setup_logger
-      testobj = OctocatalogDiff::Cli::Catalogs.new(options, logger)
+      testobj = OctocatalogDiff::Util::Catalogs.new(options, logger)
       result = testobj.send(:build_catalog_parallelizer)
       expect(logger_str.string).to match(/Initialized OctocatalogDiff::Catalog::Noop for from-catalog/)
       expect(logger_str.string).to match(/Initialized OctocatalogDiff::Catalog::Noop for to-catalog/)
@@ -276,7 +276,7 @@ describe OctocatalogDiff::Cli::Catalogs do
         OctocatalogDiff::Mocks::PuppetDB.new
       end
       logger, logger_str = OctocatalogDiff::Spec.setup_logger
-      testobj = OctocatalogDiff::Cli::Catalogs.new(options, logger)
+      testobj = OctocatalogDiff::Util::Catalogs.new(options, logger)
       result = testobj.send(:build_catalog_parallelizer)
       expect(logger_str.string).to match(/Initialized OctocatalogDiff::Catalog::JSON for to-catalog/)
       expect(logger_str.string).to match(/Initialized OctocatalogDiff::Catalog::PuppetDB for from-catalog/)
@@ -294,7 +294,7 @@ describe OctocatalogDiff::Cli::Catalogs do
     it 'should warn when catalog compilation is aborted' do
       options = { from_catalog: '-', to_catalog: '-', from_branch: 'foo', to_branch: 'bar' }
       logger, logger_str = OctocatalogDiff::Spec.setup_logger
-      testobj = OctocatalogDiff::Cli::Catalogs.new(options, logger)
+      testobj = OctocatalogDiff::Util::Catalogs.new(options, logger)
 
       pcr = double('OctocatalogDiff::Util::Parallel::Result')
       allow(pcr).to receive(:status).and_return(nil)
@@ -331,7 +331,7 @@ describe OctocatalogDiff::Cli::Catalogs do
 
       options = { from_catalog: '-', to_catalog: '-', from_branch: 'foo', to_branch: 'bar' }
       logger, logger_str = OctocatalogDiff::Spec.setup_logger
-      testobj = OctocatalogDiff::Cli::Catalogs.new(options, logger)
+      testobj = OctocatalogDiff::Util::Catalogs.new(options, logger)
 
       result = { to: '!!!', from: 'blank' }
       lines = [
@@ -342,7 +342,7 @@ describe OctocatalogDiff::Cli::Catalogs do
       answer = Regexp.new(lines.join('(.|\n)*'))
       expect do
         testobj.send(:add_parallel_result, result, pcr, key_task_tuple)
-      end.to raise_error(OctocatalogDiff::Cli::Catalogs::CatalogError, answer)
+      end.to raise_error(OctocatalogDiff::Util::Catalogs::CatalogError, answer)
 
       expect(logger_str.string).to eq('')
     end


### PR DESCRIPTION
Continuing the refactoring - this moves `cli/catalogs` to `util/catalogs` since catalog generation is not really a CLI function. (Later on the `api` will also call `util/catalogs`.)