### PR TITLE
Use diff object from API internally

### DIFF
--- a/lib/octocatalog-diff/catalog/computed.rb
+++ b/lib/octocatalog-diff/catalog/computed.rb
@@ -89,7 +89,13 @@ module OctocatalogDiff
       def cleanup_checkout_dir(checkout_dir, logger)
         return unless File.directory?(checkout_dir)
         logger.debug("Cleaning up temporary directory #{checkout_dir}")
-        FileUtils.remove_entry_secure checkout_dir
+        # Sometimes this seems to break when handling the recursive removal when running under
+        # a parallel environment. Trap and ignore the errors here if we don't care about them.
+        begin
+          FileUtils.remove_entry_secure checkout_dir
+        rescue Errno::ENOTEMPTY, Errno::ENOENT => exc
+          logger.debug "cleanup_checkout_dir(#{checkout_dir}) logged #{exc.class} - this can be ignored"
+        end
       end
 
       # Private method: Bootstrap a directory

--- a/lib/octocatalog-diff/catalog/computed.rb
+++ b/lib/octocatalog-diff/catalog/computed.rb
@@ -94,7 +94,9 @@ module OctocatalogDiff
         begin
           FileUtils.remove_entry_secure checkout_dir
         rescue Errno::ENOTEMPTY, Errno::ENOENT => exc
+          # :nocov:
           logger.debug "cleanup_checkout_dir(#{checkout_dir}) logged #{exc.class} - this can be ignored"
+          # :nocov:
         end
       end
 

--- a/lib/octocatalog-diff/cli.rb
+++ b/lib/octocatalog-diff/cli.rb
@@ -110,8 +110,8 @@ module OctocatalogDiff
       end
 
       # Compile catalogs and do catalog-diff
-      catalog_diff = OctocatalogDiff::API::V1::CatalogDiff.catalog_diff(options.merge(logger: logger))
-      diffs = catalog_diff.diffs.map(&:raw)
+      catalog_diff = OctocatalogDiff::API::V1.catalog_diff(options.merge(logger: logger))
+      diffs = catalog_diff.diffs
 
       # Display diffs
       printer_obj = OctocatalogDiff::Cli::Printer.new(options, logger)

--- a/spec/octocatalog-diff/integration/arbitrary_command_line_spec.rb
+++ b/spec/octocatalog-diff/integration/arbitrary_command_line_spec.rb
@@ -24,31 +24,23 @@ describe 'passes command line options to puppet' do
     end
 
     it 'should contain resource from environments/foo site.pp' do
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(
-               @result.diffs,
-               ['+', "File\f/tmp/environment-foo-site"]
-      )).to eq(true)
+      resource = { diff_type: '+', type: 'File', title: '/tmp/environment-foo-site' }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
     end
 
     it 'should contain resource from environments/foo modules/foo' do
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(
-               @result.diffs,
-               ['+', "File\f/tmp/environment-foo-module"]
-      )).to eq(true)
+      resource = { diff_type: '+', type: 'File', title: '/tmp/environment-foo-module' }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
     end
 
     it 'should not contain resource from environments/production' do
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(
-               @result.diffs,
-               ['+', "File\f/tmp/environment-production-site"]
-      )).to eq(false)
+      resource = { diff_type: '+', type: 'File', title: '/tmp/environment-production-site' }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(false)
     end
 
     it 'should not contain resource from main modules/foo' do
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(
-               @result.diffs,
-               ['+', "File\f/tmp/foo-module"]
-      )).to eq(false)
+      resource = { diff_type: '+', type: 'File', title: '/tmp/foo-module' }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(false)
     end
   end
 
@@ -71,24 +63,18 @@ describe 'passes command line options to puppet' do
     end
 
     it 'should contain resource from environments/foo site.pp only in to catalog' do
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(
-               @result.diffs,
-               ['+', "File\f/tmp/environment-foo-site"]
-      )).to eq(true)
+      resource = { diff_type: '+', type: 'File', title: '/tmp/environment-foo-site' }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
     end
 
     it 'should contain resource from environments/foo modules/foo only in to catalog' do
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(
-               @result.diffs,
-               ['+', "File\f/tmp/environment-foo-module"]
-      )).to eq(true)
+      resource = { diff_type: '+', type: 'File', title: '/tmp/environment-foo-module' }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
     end
 
     it 'should contain resource from environments/production only in from catalog' do
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(
-               @result.diffs,
-               ['-', "File\f/tmp/environment-production-site"]
-      )).to eq(true)
+      resource = { diff_type: '+', type: 'File', title: '/tmp/environment-production-site' }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(false)
     end
   end
 
@@ -112,31 +98,23 @@ describe 'passes command line options to puppet' do
     end
 
     it 'should contain resource from environments/foo site.pp' do
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(
-               @result.diffs,
-               ['+', "File\f/tmp/environment-foo-site"]
-      )).to eq(true)
+      resource = { diff_type: '+', type: 'File', title: '/tmp/environment-foo-site' }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
     end
 
     it 'should contain resource from environments/foo modules/foo' do
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(
-               @result.diffs,
-               ['+', "File\f/tmp/environment-foo-module"]
-      )).to eq(true)
+      resource = { diff_type: '+', type: 'File', title: '/tmp/environment-foo-module' }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
     end
 
     it 'should not contain resource from environments/production' do
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(
-               @result.diffs,
-               ['+', "File\f/tmp/environment-production-site"]
-      )).to eq(false)
+      resource = { diff_type: '+', type: 'File', title: '/tmp/environment-production-site' }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(false)
     end
 
     it 'should not contain resource from main modules/foo' do
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(
-               @result.diffs,
-               ['+', "File\f/tmp/foo-module"]
-      )).to eq(false)
+      resource = { diff_type: '+', type: 'File', title: '/tmp/foo-module' }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(false)
     end
   end
 
@@ -160,31 +138,23 @@ describe 'passes command line options to puppet' do
     end
 
     it 'should contain resource from environments/foo site.pp' do
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(
-               @result.diffs,
-               ['+', "File\f/tmp/environment-foo-site"]
-      )).to eq(true)
+      resource = { diff_type: '+', type: 'File', title: '/tmp/environment-foo-site' }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
     end
 
     it 'should not contain resource from environments/foo modules/foo' do
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(
-               @result.diffs,
-               ['+', "File\f/tmp/environment-foo-module"]
-      )).to eq(false)
+      resource = { diff_type: '+', type: 'File', title: '/tmp/environment-foo-module' }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(false)
     end
 
     it 'should not contain resource from environments/production' do
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(
-               @result.diffs,
-               ['+', "File\f/tmp/environment-production-site"]
-      )).to eq(false)
+      resource = { diff_type: '+', type: 'File', title: '/tmp/environment-production-site' }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(false)
     end
 
     it 'should contain resource from main modules/foo' do
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(
-               @result.diffs,
-               ['+', "File\f/tmp/foo-module"]
-      )).to eq(true)
+      resource = { diff_type: '+', type: 'File', title: '/tmp/foo-module' }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
     end
   end
 end

--- a/spec/octocatalog-diff/integration/bootstrap_script_spec.rb
+++ b/spec/octocatalog-diff/integration/bootstrap_script_spec.rb
@@ -92,18 +92,8 @@ describe 'bootstrap script integration test' do
       end
 
       it 'should contain the added resource' do
-        answer = [
-          '+',
-          "File\f/tmp/foo",
-          {
-            'type' => 'File',
-            'title' => '/tmp/foo',
-            'tags' => %w(class file test),
-            'exported' => false,
-            'parameters' => { 'content' => "Test 123\n" }
-          }
-        ]
-        expect(OctocatalogDiff::Spec.array_contains_partial_array?(@result[:diffs], answer)).to eq(true)
+        resource = { diff_type: '+', type: 'File', title: '/tmp/foo' }
+        expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
       end
 
       it 'should print debugging output from bootstrap script' do
@@ -139,18 +129,8 @@ describe 'bootstrap script integration test' do
       end
 
       it 'should contain the added resource' do
-        answer = [
-          '+',
-          "File\f/tmp/foo",
-          {
-            'type' => 'File',
-            'title' => '/tmp/foo',
-            'tags' => %w(class file test),
-            'exported' => false,
-            'parameters' => { 'content' => "Test 123\n" }
-          }
-        ]
-        expect(OctocatalogDiff::Spec.array_contains_partial_array?(@result[:diffs], answer)).to eq(true)
+        resource = { diff_type: '+', type: 'File', title: '/tmp/foo' }
+        expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
       end
 
       it 'should not print debugging output from bootstrap script' do

--- a/spec/octocatalog-diff/integration/convert_file_resources_spec.rb
+++ b/spec/octocatalog-diff/integration/convert_file_resources_spec.rb
@@ -27,23 +27,39 @@ describe 'convert file resources' do
     end
 
     it 'should contain /tmp/foo1' do
-      answer = ['~', "File\f/tmp/foo1\fparameters\fcontent", "content of foo-old\n", "content of foo-new\n"]
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(@result[:diffs], answer)).to eq(true)
+      resource = {
+        diff_type: '~',
+        type: 'File',
+        title: '/tmp/foo1',
+        structure: %w(parameters content),
+        old_value: "content of foo-old\n",
+        new_value: "content of foo-new\n"
+      }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
     end
 
     it 'should contain /tmp/binary1' do
-      answer = [
-        '~',
-        "File\f/tmp/binary1\fparameters\fcontent",
-        '{md5}e0897d525d5d600a037622b62fc99a4c',
-        '{md5}97918b387001eb04ae7cb20b13e07f43'
-      ]
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(@result[:diffs], answer)).to eq(true)
+      resource = {
+        diff_type: '~',
+        type: 'File',
+        title: '/tmp/binary1',
+        structure: %w(parameters content),
+        old_value: '{md5}e0897d525d5d600a037622b62fc99a4c',
+        new_value: '{md5}97918b387001eb04ae7cb20b13e07f43'
+      }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
     end
 
     it 'should contain /tmp/bar2' do
-      answer = ['~', "File\f/tmp/bar2\fparameters\fcontent", "content of bar\n", "content of new-bar\n"]
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(@result[:diffs], answer)).to eq(true)
+      resource = {
+        diff_type: '~',
+        type: 'File',
+        title: '/tmp/bar2',
+        structure: %w(parameters content),
+        old_value: "content of bar\n",
+        new_value: "content of new-bar\n"
+      }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
     end
   end
 
@@ -71,38 +87,63 @@ describe 'convert file resources' do
     end
 
     it 'should contain /tmp/binary1' do
-      answer = [
-        '~',
-        "File\f/tmp/binary1\fparameters\fsource",
-        'puppet:///modules/test/binary-old',
-        'puppet:///modules/test/binary-new'
-      ]
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(@result[:diffs], answer)).to eq(true)
+      resource = {
+        diff_type: '~',
+        type: 'File',
+        title: '/tmp/binary1',
+        structure: %w(parameters source),
+        old_value: 'puppet:///modules/test/binary-old',
+        new_value: 'puppet:///modules/test/binary-new'
+      }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
     end
 
     it 'should contain /tmp/binary3' do
-      answer = [
-        '~',
-        "File\f/tmp/binary3\fparameters\fsource",
-        'puppet:///modules/test/binary-old',
-        'puppet:///modules/test/binary-old2'
-      ]
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(@result[:diffs], answer)).to eq(true)
+      resource = {
+        diff_type: '~',
+        type: 'File',
+        title: '/tmp/binary3',
+        structure: %w(parameters source),
+        old_value: 'puppet:///modules/test/binary-old',
+        new_value: 'puppet:///modules/test/binary-old2'
+      }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
     end
 
     it 'should contain /tmp/foo1' do
-      answer = ['~', "File\f/tmp/foo1\fparameters\fsource", 'puppet:///modules/test/foo-old', 'puppet:///modules/test/foo-new']
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(@result[:diffs], answer)).to eq(true)
+      resource = {
+        diff_type: '~',
+        type: 'File',
+        title: '/tmp/foo1',
+        structure: %w(parameters source),
+        old_value: 'puppet:///modules/test/foo-old',
+        new_value: 'puppet:///modules/test/foo-new'
+      }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
     end
 
     it 'should contain /tmp/bar content' do
-      answer = ['!', "File\f/tmp/bar\fparameters\fcontent", nil, "content of bar\n"]
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(@result[:diffs], answer)).to eq(true)
+      resource = {
+        diff_type: '!',
+        type: 'File',
+        title: '/tmp/bar',
+        structure: %w(parameters content),
+        old_value: nil,
+        new_value: "content of bar\n"
+      }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
     end
 
     it 'should contain /tmp/bar source' do
-      answer = ['!', "File\f/tmp/bar\fparameters\fsource", 'puppet:///modules/test/bar-old', nil]
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(@result[:diffs], answer)).to eq(true)
+      resource = {
+        diff_type: '!',
+        type: 'File',
+        title: '/tmp/bar',
+        structure: %w(parameters source),
+        old_value: 'puppet:///modules/test/bar-old',
+        new_value: nil
+      }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
     end
   end
 

--- a/spec/octocatalog-diff/integration/modulepath_spec.rb
+++ b/spec/octocatalog-diff/integration/modulepath_spec.rb
@@ -69,19 +69,25 @@ describe 'multiple module paths' do
     end
 
     let(:module_answer) do
-      ['~',
-       "File\f/tmp/modulestest\fparameters\fcontent",
-       "Modules Test\n",
-       "New content of modulestest\n"]
+      {
+        diff_type: '~',
+        type: 'File',
+        title: '/tmp/modulestest',
+        structure: %w(parameters content),
+        old_value: "Modules Test\n",
+        new_value: "New content of modulestest\n"
+      }
     end
 
     let(:site_answer) do
-      [
-        '~',
-        "File\f/tmp/sitetest\fparameters\fcontent",
-        "Site Test\n",
-        "New content of sitetest\n"
-      ]
+      {
+        diff_type: '~',
+        type: 'File',
+        title: '/tmp/sitetest',
+        structure: %w(parameters content),
+        old_value: "Site Test\n",
+        new_value: "New content of sitetest\n"
+      }
     end
 
     context 'with environment.conf' do
@@ -102,8 +108,8 @@ describe 'multiple module paths' do
         expect(@result[:exitcode]).to eq(2), OctocatalogDiff::Integration.format_exception(@result)
         expect(@result[:diffs]).to be_a_kind_of(Array)
         expect(@result[:diffs].size).to eq(2)
-        expect(OctocatalogDiff::Spec.array_contains_partial_array?(@result[:diffs], module_answer)).to eq(true)
-        expect(OctocatalogDiff::Spec.array_contains_partial_array?(@result[:diffs], site_answer)).to eq(true)
+        expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], module_answer)).to eq(true)
+        expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], site_answer)).to eq(true)
       end
     end
 
@@ -125,8 +131,8 @@ describe 'multiple module paths' do
         expect(@result[:exitcode]).to eq(2), OctocatalogDiff::Integration.format_exception(@result)
         expect(@result[:diffs]).to be_a_kind_of(Array)
         expect(@result[:diffs].size).to eq(2)
-        expect(OctocatalogDiff::Spec.array_contains_partial_array?(@result[:diffs], module_answer)).to eq(true)
-        expect(OctocatalogDiff::Spec.array_contains_partial_array?(@result[:diffs], site_answer)).to eq(true)
+        expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], module_answer)).to eq(true)
+        expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], site_answer)).to eq(true)
       end
     end
   end

--- a/spec/octocatalog-diff/integration/preserve_environments_spec.rb
+++ b/spec/octocatalog-diff/integration/preserve_environments_spec.rb
@@ -151,35 +151,45 @@ describe 'preserve environments integration' do
         end
 
         it 'should display proper diffs' do
-          diffs = @result.diffs
+          resource = {
+            diff_type: '~',
+            type: 'File',
+            title: '/tmp/bar',
+            structure: %w(parameters content),
+            old_value: 'one',
+            new_value: 'two'
+          }
+          expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
 
-          expect(
-            OctocatalogDiff::Spec.array_contains_partial_array?(
-              diffs,
-              ['~', "File\f/tmp/bar\fparameters\fcontent", 'one', 'two']
-            )
-          ).to eq(true)
+          resource = {
+            diff_type: '~',
+            type: 'File',
+            title: '/tmp/bar',
+            structure: %w(parameters owner),
+            old_value: 'one',
+            new_value: 'two'
+          }
+          expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
 
-          expect(
-            OctocatalogDiff::Spec.array_contains_partial_array?(
-              diffs,
-              ['~', "File\f/tmp/bar\fparameters\fowner", 'one', 'two']
-            )
-          ).to eq(true)
+          resource = {
+            diff_type: '~',
+            type: 'File',
+            title: '/tmp/foo',
+            structure: %w(parameters content),
+            old_value: 'one',
+            new_value: 'two'
+          }
+          expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
 
-          expect(
-            OctocatalogDiff::Spec.array_contains_partial_array?(
-              diffs,
-              ['~', "File\f/tmp/foo\fparameters\fcontent", 'one', 'two']
-            )
-          ).to eq(true)
-
-          expect(
-            OctocatalogDiff::Spec.array_contains_partial_array?(
-              diffs,
-              ['~', "File\f/tmp/sitetest\fparameters\fcontent", 'one', 'two']
-            )
-          ).to eq(true)
+          resource = {
+            diff_type: '~',
+            type: 'File',
+            title: '/tmp/sitetest',
+            structure: %w(parameters content),
+            old_value: 'one',
+            new_value: 'two'
+          }
+          expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
         end
 
         it 'should handle hieradata properly' do

--- a/spec/octocatalog-diff/integration/reference_validation_spec.rb
+++ b/spec/octocatalog-diff/integration/reference_validation_spec.rb
@@ -255,19 +255,8 @@ describe 'validation of references in catalog-diff' do
       diffs = @result.diffs
       expect(diffs).to be_a_kind_of(Array)
       expect(diffs.size).to eq(1)
-
-      answer = [
-        '-',
-        "Exec\fbefore caller",
-        {
-          'type' => 'Exec',
-          'title' => 'before caller',
-          'tags' => ['before_callers', 'class', 'default', 'exec', 'node', 'test', 'test::before_callers'],
-          'exported' => false,
-          'parameters' => { 'command' => '/bin/true' }
-        }
-      ]
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(diffs, answer)).to eq(true)
+      resource = { diff_type: '-', type: 'Exec', title: 'before caller' }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
     end
   end
 

--- a/spec/octocatalog-diff/integration/yaml_diff_spec.rb
+++ b/spec/octocatalog-diff/integration/yaml_diff_spec.rb
@@ -21,27 +21,23 @@ describe 'YAML file suppression for identical diffs' do
     end
 
     it 'should contain the "similar JSON" static file as a diff' do
-      arr = @result.diffs
-      answer = ['~', "File\f/tmp/static/similar-yaml.json\fparameters\fcontent"]
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(arr, answer)).to eq(true)
+      resource = { diff_type: '~', type: 'File', title: '/tmp/static/similar-yaml.json', structure: %w(parameters content) }
+      expect(OctocatalogDiff::Spec.diff_match?(@result.diffs, resource)).to eq(true)
     end
 
     it 'should contain the "similar YAML" static file as a diff' do
-      arr = @result.diffs
-      answer = ['~', "File\f/tmp/static/similar-yaml.yaml\fparameters\fcontent"]
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(arr, answer)).to eq(true)
+      resource = { diff_type: '~', type: 'File', title: '/tmp/static/similar-yaml.yaml', structure: %w(parameters content) }
+      expect(OctocatalogDiff::Spec.diff_match?(@result.diffs, resource)).to eq(true)
     end
 
     it 'should contain the "similar JSON" template file as a diff' do
-      arr = @result.diffs
-      answer = ['~', "File\f/tmp/template/similar-yaml.json\fparameters\fcontent"]
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(arr, answer)).to eq(true)
+      resource = { diff_type: '~', type: 'File', title: '/tmp/template/similar-yaml.json', structure: %w(parameters content) }
+      expect(OctocatalogDiff::Spec.diff_match?(@result.diffs, resource)).to eq(true)
     end
 
     it 'should contain the "similar YAML" template file as a diff' do
-      arr = @result.diffs
-      answer = ['~', "File\f/tmp/template/similar-yaml.yaml\fparameters\fcontent"]
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(arr, answer)).to eq(true)
+      resource = { diff_type: '~', type: 'File', title: '/tmp/template/similar-yaml.yaml', structure: %w(parameters content) }
+      expect(OctocatalogDiff::Spec.diff_match?(@result.diffs, resource)).to eq(true)
     end
   end
 
@@ -62,27 +58,23 @@ describe 'YAML file suppression for identical diffs' do
     end
 
     it 'should contain the "similar JSON" static file as a diff' do
-      arr = @result.diffs
-      answer = ['~', "File\f/tmp/static/similar-yaml.json\fparameters\fcontent"]
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(arr, answer)).to eq(true)
+      resource = { diff_type: '~', type: 'File', title: '/tmp/static/similar-yaml.json', structure: %w(parameters content) }
+      expect(OctocatalogDiff::Spec.diff_match?(@result.diffs, resource)).to eq(true)
     end
 
     it 'should not contain the "similar YAML" static file as a diff' do
-      arr = @result.diffs
-      answer = ['~', "File\f/tmp/static/similar-yaml.yaml\fparameters\fcontent"]
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(arr, answer)).to eq(false)
+      resource = { diff_type: '~', type: 'File', title: '/tmp/static/similar-yaml.yaml', structure: %w(parameters content) }
+      expect(OctocatalogDiff::Spec.diff_match?(@result.diffs, resource)).to eq(false)
     end
 
     it 'should contain the "similar JSON" template file as a diff' do
-      arr = @result.diffs
-      answer = ['~', "File\f/tmp/template/similar-yaml.json\fparameters\fcontent"]
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(arr, answer)).to eq(true)
+      resource = { diff_type: '~', type: 'File', title: '/tmp/template/similar-yaml.json', structure: %w(parameters content) }
+      expect(OctocatalogDiff::Spec.diff_match?(@result.diffs, resource)).to eq(true)
     end
 
     it 'should not contain the "similar YAML" template file as a diff' do
-      arr = @result.diffs
-      answer = ['~', "File\f/tmp/template/similar-yaml.yaml\fparameters\fcontent"]
-      expect(OctocatalogDiff::Spec.array_contains_partial_array?(arr, answer)).to eq(false)
+      resource = { diff_type: '~', type: 'File', title: '/tmp/template/similar-yaml.yaml', structure: %w(parameters content) }
+      expect(OctocatalogDiff::Spec.diff_match?(@result.diffs, resource)).to eq(false)
     end
   end
 end

--- a/spec/octocatalog-diff/tests/spec_helper.rb
+++ b/spec/octocatalog-diff/tests/spec_helper.rb
@@ -122,6 +122,25 @@ module OctocatalogDiff
       false
     end
 
+    # Determine if a OctocatalogDiff::API::V1::Diff (or an array of those) matches a lookup hash. This
+    # returns true if the object (or any object in the array) matches all keys given in the lookup hash.
+    # @param diff_in [OctocatalogDiff::API::V1::Diff or Array<OctocatalogDiff::API::V1::Diff>] diff(s) to search
+    # @param lookup [Hash] Lookup hash
+    def self.diff_match?(diff_in, lookup)
+      diffs = [diff_in].flatten
+      diffs.each do |diff|
+        flag = true
+        lookup.to_h.each do |key, val|
+          unless diff.send(key) == val
+            flag = false
+            break
+          end
+        end
+        return true if flag
+      end
+      false
+    end
+
     # Mock out a small shell script that tests for environment variable setting.
     # This takes the LAST command line argument, gets the value of that variable,
     # and prints it to STDERR.


### PR DESCRIPTION
This pull request changes the CLI class to use the catalog-diff API (and specifically the Diff object) instead of the raw objects. This is done mostly for dog-fooding of the API.