### PR TITLE
Rename file so it gets run and add test for `.config` method

### DIFF
--- a/spec/octocatalog-diff/tests/api/v1_spec.rb
+++ b/spec/octocatalog-diff/tests/api/v1_spec.rb
@@ -20,4 +20,12 @@ describe OctocatalogDiff::API::V1 do
       expect { described_class.catalog_diff(args) }.not_to raise_error
     end
   end
+
+  describe '#config' do
+    it 'should call CatalogDiff.config with passed-in arguments' do
+      args = { foo: 'bar' }
+      expect(OctocatalogDiff::API::V1::Config).to receive(:config).with(args)
+      expect { described_class.config(args) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes the spec test for `lib/octocatalog-diff/api/v1.rb` by naming it properly so it gets run, and adds coverage for the `.config` method as well.