### PR TITLE
JSON output

### DIFF
--- a/doc/dev/api/v1/objects/diff.md
+++ b/doc/dev/api/v1/objects/diff.md
@@ -44,6 +44,10 @@ Note that this is a pass-through of information provided in the Puppet catalog, 
 
 Note also that if the diff represents removal of a resource, this will return `nil`, because the resource does not exist in the new catalog.
 
+#### `#new_location` (Hash)
+
+Returns a hash containing `:file` (equal to `#new_file`) and `:line` (equal to `#new_line`) when either is defined. Returns `nil` if both are undefined.
+
 #### `#new_value` (Object)
 
 Returns the value of the resource from the new catalog.
@@ -110,6 +114,10 @@ Returns the line number within the Puppet manifest giving rise to the resource a
 Note that this is a pass-through of information provided in the Puppet catalog, and is not calculated by octocatalog-diff. If the Puppet catalog does not contain this information, this method will return `nil`.
 
 Note also that if the diff represents addition of a resource, this will return `nil`, because the resource does not exist in the old catalog.
+
+#### `#old_location` (Hash)
+
+Returns a hash containing `:file` (equal to `#old_file`) and `:line` (equal to `#old_line`) when either is defined. Returns `nil` if both are undefined.
 
 #### `#old_value` (Object)
 
@@ -249,4 +257,5 @@ These methods are available for debugging or development purposes but are not gu
 - `#inspect` (String): Returns inspection of object
 - `#raw` (Array): Returns internal array data structure of the "diff"
 - `#to_h` (Hash): Returns object as a hash, where keys are above described methods
+- `#to_h_with_string_keys` (Hash): Returns object as a hash, where keys are above described methods; keys are strings, not symbols
 - `#[]` (Object): Retrieve indexed array elements from raw internal array object

--- a/doc/optionsref.md
+++ b/doc/optionsref.md
@@ -27,7 +27,7 @@ Usage: octocatalog-diff [command line options]
         --bootstrap-then-exit        Bootstrap from-dir and/or to-dir and then exit
         --[no-]color                 Enable/disable colors in output
     -o, --output-file FILENAME       Output results into FILENAME
-        --output-format FORMAT       Output format: text,json
+        --output-format FORMAT       Output format: text,json,legacy_json
     -d, --[no-]debug                 Print debugging messages to STDERR
     -q, --[no-]quiet                 Quiet (no status messages except errors)
         --ignore "Type1[Title1],Type2[Title2],..."
@@ -708,10 +708,12 @@ to ignore any changes for any defined type where this tag is set. (<a href="../l
       <pre><code>--output-format FORMAT</code></pre>
     </td>
     <td valign=top>
-      Output format: text,json
+      Output format: text,json,legacy_json
     </td>
     <td valign=top>
-      Output format option (<a href="../lib/octocatalog-diff/cli/options/output_format.rb">output_format.rb</a>)
+      Output format option. 'text' is human readable text, 'json' is an array of differences
+identified by human readable keys (the preferred octocatalog-diff 1.x format), and 'legacy_json' is an
+array of differences, where each difference is an array (the octocatalog-diff 0.x format). (<a href="../lib/octocatalog-diff/cli/options/output_format.rb">output_format.rb</a>)
     </td>
   </tr>
 

--- a/lib/octocatalog-diff/api/v1/diff.rb
+++ b/lib/octocatalog-diff/api/v1/diff.rb
@@ -22,8 +22,13 @@ module OctocatalogDiff
         # Constructor: Accepts a diff in the traditional array format and stores it.
         # @param raw [Array] Diff in the traditional format
         def initialize(raw)
+          if raw.is_a?(OctocatalogDiff::API::V1::Diff)
+            @raw = raw.raw
+            return
+          end
+
           unless raw.is_a?(Array)
-            raise ArgumentError, 'OctocatalogDiff::API::V1::Diff#initialize expects Array argument'
+            raise ArgumentError, "OctocatalogDiff::API::V1::Diff#initialize expects Array argument (got #{raw.class})"
           end
           @raw = raw
         end

--- a/lib/octocatalog-diff/api/v1/diff.rb
+++ b/lib/octocatalog-diff/api/v1/diff.rb
@@ -119,6 +119,22 @@ module OctocatalogDiff
           x.nil? ? nil : x['line']
         end
 
+        # Public: Get the "old" location, i.e. location in the "from" catalog
+        # @return [Hash] <file:, line:> of resource
+        def old_location
+          return nil if addition?
+          return @raw[3] if removal?
+          @raw[4]
+        end
+
+        # Public: Get the "new" location, i.e. location in the "to" catalog
+        # @return [Hash] <file:, line:> of resource
+        def new_location
+          return @raw[3] if addition?
+          return nil if removal?
+          @raw[5]
+        end
+
         # Public: Convert this object to a hash
         # @return [Hash] Hash with keys set by these methods
         def to_h
@@ -132,8 +148,18 @@ module OctocatalogDiff
             old_file: old_file,
             old_line: old_line,
             new_file: new_file,
-            new_line: new_line
+            new_line: new_line,
+            old_location: old_location,
+            new_location: new_location
           }
+        end
+
+        # Public: Convert this object to a hash with string keys
+        # @return [Hash] Hash with keys set by these methods, with string keys
+        def to_h_with_string_keys
+          result = {}
+          to_h.each { |key, val| result[key.to_s] = val }
+          result
         end
 
         # Public: String inspection
@@ -146,24 +172,6 @@ module OctocatalogDiff
         # @return [String] Compact string representation
         def to_s
           raw.inspect
-        end
-
-        private
-
-        # Private: Get the "old" location, i.e. location in the "from" catalog
-        # @return [Hash] <file:, line:> of resource
-        def old_location
-          return nil if addition?
-          return @raw[3] if removal?
-          @raw[4]
-        end
-
-        # Private: Get the "new" location, i.e. location in the "to" catalog
-        # @return [Hash] <file:, line:> of resource
-        def new_location
-          return @raw[3] if addition?
-          return nil if removal?
-          @raw[5]
         end
       end
     end

--- a/lib/octocatalog-diff/catalog-diff/display.rb
+++ b/lib/octocatalog-diff/catalog-diff/display.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
+require_relative '../api/v1/diff'
 require_relative 'differ'
 require_relative 'display/json'
+require_relative 'display/legacy_json'
 require_relative 'display/text'
 
 module OctocatalogDiff
@@ -21,8 +23,9 @@ module OctocatalogDiff
       # @param logger [Logger] Logger object
       # @return [String] Text output for provided diff
       def self.output(diff_in, options = {}, logger = nil)
-        diff = diff_in.is_a?(OctocatalogDiff::CatalogDiff::Differ) ? diff_in.diff : diff_in
-        raise ArgumentError, "text_output requires Array<Diff results>; passed in #{diff_in.class}" unless diff.is_a?(Array)
+        diff_x = diff_in.is_a?(OctocatalogDiff::CatalogDiff::Differ) ? diff_in.diff : diff_in
+        raise ArgumentError, "text_output requires Array<Diff results>; passed in #{diff_in.class}" unless diff_x.is_a?(Array)
+        diff = diff_x.map { |x| OctocatalogDiff::API::V1::Diff.new(x) }
 
         # req_format means 'requested format' because 'format' has a built-in meaning to Ruby
         req_format = options.fetch(:format, :color_text)
@@ -41,6 +44,9 @@ module OctocatalogDiff
         when :json
           logger.debug 'Generating JSON output' if logger
           OctocatalogDiff::CatalogDiff::Display::Json.generate(diff, opts, logger)
+        when :legacy_json
+          logger.debug 'Generating Legacy JSON output' if logger
+          OctocatalogDiff::CatalogDiff::Display::LegacyJson.generate(diff, opts, logger)
         when :text
           logger.debug 'Generating non-colored text output' if logger
           OctocatalogDiff::CatalogDiff::Display::Text.generate(diff, opts.merge(color: false), logger)

--- a/lib/octocatalog-diff/catalog-diff/display/legacy_json.rb
+++ b/lib/octocatalog-diff/catalog-diff/display/legacy_json.rb
@@ -7,9 +7,9 @@ require 'json'
 module OctocatalogDiff
   module CatalogDiff
     class Display
-      # Display the output from a diff in JSON format. This is the new format, used in octocatalog-diff
-      # 1.x, where each diff is represented by an hash with named keys.
-      class Json < OctocatalogDiff::CatalogDiff::Display
+      # Display the output from a diff in JSON format. This is the legacy format, used in octocatalog-diff
+      # 0.x, where each diff is represented by an array.
+      class LegacyJson < OctocatalogDiff::CatalogDiff::Display
         # Generate JSON representation of the 'diff' suitable for further analysis.
         # @param diff [Array<Diff results>] The diff which *must* be in this format
         # @param options [Hash] Options which are:
@@ -17,7 +17,7 @@ module OctocatalogDiff
         # @param _logger [Logger] Not used here
         def self.generate(diff, options = {}, _logger = nil)
           result = {
-            'diff' => diff.map(&:to_h_with_string_keys)
+            'diff' => diff.map(&:raw)
           }
           result['header'] = options[:header] unless options[:header].nil?
           result.to_json

--- a/lib/octocatalog-diff/cli/options/output_format.rb
+++ b/lib/octocatalog-diff/cli/options/output_format.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
-# Output format option
+# Output format option. 'text' is human readable text, 'json' is an array of differences
+# identified by human readable keys (the preferred octocatalog-diff 1.x format), and 'legacy_json' is an
+# array of differences, where each difference is an array (the octocatalog-diff 0.x format).
 # @param parser [OptionParser object] The OptionParser argument
 # @param options [Hash] Options hash being constructed; this is modified in this method.
 OctocatalogDiff::Cli::Options::Option.newoption(:output_format) do
   has_weight 100
 
   def parse(parser, options)
-    valid = %w(text json)
+    valid = %w(text json legacy_json)
     parser.on('--output-format FORMAT', "Output format: #{valid.join(',')}") do |fmt|
       raise ArgumentError, "Invalid format. Must be one of: #{valid.join(',')}" unless valid.include?(fmt)
       options[:format] = fmt.to_sym

--- a/lib/octocatalog-diff/cli/printer.rb
+++ b/lib/octocatalog-diff/cli/printer.rb
@@ -19,10 +19,13 @@ module OctocatalogDiff
       # The method to call externally, passing in diffs. This takes the appropriate action
       # based on options, which is either to write the result into an output file, or print
       # the result on STDOUT. Does not return anything.
-      # @param diffs [OctocatalogDiff::CatalogDiff::Differ] Difference array
+      # @param diffs [Array<Diffs>] Array of differences
       # @param from_dir [String] Directory in which "from" catalog was compiled
       # @param to_dir [String] Directory in which "to" catalog was compiled
       def printer(diffs, from_dir = nil, to_dir = nil)
+        unless diffs.is_a?(Array)
+          raise ArgumentError, "printer() expects an array, not #{diffs.class}"
+        end
         display_opts = @options.merge(compilation_from_dir: from_dir, compilation_to_dir: to_dir)
         diff_text = OctocatalogDiff::CatalogDiff::Display.output(diffs, display_opts, @logger)
         if @options[:output_file].nil?

--- a/spec/octocatalog-diff/tests/api/v1/diff_spec.rb
+++ b/spec/octocatalog-diff/tests/api/v1/diff_spec.rb
@@ -350,6 +350,12 @@ describe OctocatalogDiff::API::V1::Diff do
   end
 
   describe '#initialize' do
+    it 'should set up raw object when called with an instance of itself' do
+      obj1 = described_class.new(chg_2)
+      testobj = described_class.new(obj1)
+      expect(testobj.raw).to eq(chg_2)
+    end
+
     it 'should raise ArgumentError if called with a non-array' do
       expect { described_class.new('foo') }.to raise_error(ArgumentError)
     end

--- a/spec/octocatalog-diff/tests/api/v1/diff_spec.rb
+++ b/spec/octocatalog-diff/tests/api/v1/diff_spec.rb
@@ -273,15 +273,64 @@ describe OctocatalogDiff::API::V1::Diff do
     end
   end
 
+  describe '#old_location' do
+    it 'should return nil for addition' do
+      testobj = described_class.new(add_2)
+      expect(testobj.old_location).to be_nil
+    end
+
+    it 'should return location for removal' do
+      testobj = described_class.new(del_2)
+      expect(testobj.old_location).to eq(loc_1)
+    end
+
+    it 'should return location for change' do
+      testobj = described_class.new(chg_2)
+      expect(testobj.old_location).to eq(loc_1)
+    end
+  end
+
+  describe '#new_location' do
+    it 'should return location for addition' do
+      testobj = described_class.new(add_2)
+      expect(testobj.new_location).to eq(loc_2)
+    end
+
+    it 'should return nil for removal' do
+      testobj = described_class.new(del_2)
+      expect(testobj.new_location).to be_nil
+    end
+
+    it 'should return location for change' do
+      testobj = described_class.new(chg_2)
+      expect(testobj.new_location).to eq(loc_2)
+    end
+  end
+
   describe '#to_h' do
     it 'should return a hash with the expected keys and values' do
-      methods = %w(diff_type type title structure old_value new_value old_line new_line old_file new_file)
+      methods = %w(diff_type type title structure old_value new_value)
+                .concat %w(old_line new_line old_file new_file old_location new_location)
       testobj = described_class.new(chg_2)
       result = testobj.to_h
       methods.each do |method_name|
         method = method_name.to_sym
         expect(result.key?(method)).to eq(true)
         expect(result[method]).to eq(testobj.send(method))
+      end
+    end
+  end
+
+  describe '#to_h_with_string_keys' do
+    it 'should return a hash with the expected keys and values' do
+      methods = %w(diff_type type title structure old_value new_value)
+                .concat %w(old_line new_line old_file new_file old_location new_location)
+      testobj = described_class.new(chg_2)
+      result = testobj.to_h_with_string_keys
+      methods.each do |method_name|
+        method = method_name.to_sym
+        expect(result.key?(method.to_s)).to eq(true)
+        expect(result[method.to_s]).to eq(testobj.send(method))
       end
     end
   end

--- a/spec/octocatalog-diff/tests/catalog-diff/display_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-diff/display_spec.rb
@@ -41,14 +41,49 @@ describe OctocatalogDiff::CatalogDiff::Display do
       expect(result.first).to eq('+ Class[Fizzbuzz]')
     end
 
+    it 'should call OctocatalogDiff::CatalogDiff::Display::LegacyJson' do
+      opts = {
+        format: :legacy_json,
+        header: 'My awesome header'
+      }
+      answer = [
+        [
+          '+',
+          "Class\fFizzbuzz",
+          { 'type' => 'Class', 'title' => 'Fizzbuzz', 'tags' => %w(class fizzbuzz), 'exported' => false },
+          { 'file' => nil, 'line' => nil }
+        ]
+      ]
+      result = OctocatalogDiff::CatalogDiff::Display.output(differ, opts)
+      parse_result = JSON.parse(result)
+      expect(parse_result['diff']).to eq(answer)
+      expect(parse_result['header']).to eq('My awesome header')
+    end
+
     it 'should call OctocatalogDiff::CatalogDiff::Display::Json' do
       opts = {
         format: :json,
         header: 'My awesome header'
       }
+      answer = [
+        {
+          'diff_type' => '+',
+          'type' => 'Class',
+          'title' => 'Fizzbuzz',
+          'structure' => [],
+          'old_value' => nil,
+          'new_value' => { 'type' => 'Class', 'title' => 'Fizzbuzz', 'tags' => %w(class fizzbuzz), 'exported' => false },
+          'old_file' => nil,
+          'old_line' => nil,
+          'new_file' => nil,
+          'new_line' => nil,
+          'old_location' => nil,
+          'new_location' => { 'file' => nil, 'line' => nil }
+        }
+      ]
       result = OctocatalogDiff::CatalogDiff::Display.output(differ, opts)
       parse_result = JSON.parse(result)
-      expect(parse_result['diff']).to eq(differ.diff)
+      expect(parse_result['diff']).to eq(answer)
       expect(parse_result['header']).to eq('My awesome header')
     end
 

--- a/spec/octocatalog-diff/tests/cli/options/output_format_spec.rb
+++ b/spec/octocatalog-diff/tests/cli/options/output_format_spec.rb
@@ -4,7 +4,7 @@ require_relative '../options_helper'
 
 describe OctocatalogDiff::Cli::Options do
   describe '#opt_output_format' do
-    valid = %w(text json)
+    valid = %w(text json legacy_json)
     valid.each do |fmt|
       it "should set output format to #{fmt}" do
         result = run_optparse(['--output-format', fmt])

--- a/spec/octocatalog-diff/tests/cli/printer_spec.rb
+++ b/spec/octocatalog-diff/tests/cli/printer_spec.rb
@@ -14,6 +14,13 @@ describe OctocatalogDiff::Cli::Printer do
       @diff = JSON.parse(File.read(OctocatalogDiff::Spec.fixture_path('diffs/catalog-1-vs-catalog-2.json')))
     end
 
+    it 'should raise an ArgumentError when called with something other than an array' do
+      testobj = described_class.new(nil, nil)
+      expect do
+        testobj.printer(:foo)
+      end.to raise_error(ArgumentError, 'printer() expects an array, not Symbol')
+    end
+
     it 'should write to a file when options output_file is specified' do
       begin
         # Set up the tempfile to output to.


### PR DESCRIPTION
This PR:

- Changes the default JSON output from an array:

  ```
  ["~", "File\f/etc/foo\fparameters\fcontent", ...]
  ```

  to a hash with meaningful keys:

  ```
  { "diff_type": "~", "type": "File", "title": "/etc/foo", ... }
  ```

- Adds an output format named `legacy_json` to output the old way.