### PR TITLE
Add examples for catalog-diff API

### DIFF
--- a/examples/api/v1/catalog-diff-git-repo.rb
+++ b/examples/api/v1/catalog-diff-git-repo.rb
@@ -1,0 +1,101 @@
+#!/usr/bin/env ruby
+
+# ------------------------------------------------------------------------------------
+# This is a script that demonstrates the use of the OctocatalogDiff::API::V1.catalog_diff
+# method to compare two catalogs.
+#
+# Run this with:
+#   bundle exec examples/api/v1/catalog-diff-local-files.rb
+#
+# In this example, we'll compare two catalogs, based on branches from a git repository.
+# ------------------------------------------------------------------------------------
+
+# Once you have installed the gem, you want this:
+#
+# require 'octocatalog-diff'
+#
+# To make the script run correctly from within the `examples` directory, this locates
+# the `octocatalog-diff` gem directly from this checkout.
+require_relative '../../../lib/octocatalog-diff'
+
+# Here are a few variables we'll use to compile this catalog. To ensure that this is a
+# working script, it will use resources from the test fixtures. You will need adjust these
+# to the actual values in your application.
+FACT_FILE = File.expand_path('../../../spec/octocatalog-diff/fixtures/facts/facts.yaml', File.dirname(__FILE__))
+NODE = 'rspec-node.github.net'.freeze
+GIT_TARBALL = File.expand_path('../../../spec/octocatalog-diff/fixtures/git-repos/simple-repo.tar', File.dirname(__FILE__))
+PUPPET_BINARY = File.expand_path('../../../script/puppet', File.dirname(__FILE__))
+
+# Before we get started with the demo, I need to extract the tarball to create the git repo.
+# You won't be doing this in your own script, so as the great and powerful Oz says, "pay no
+# attention to the man behind the curtain."
+require 'fileutils'
+git_repo = Dir.mktmpdir
+at_exit { FileUtils.remove_entry_secure git_repo if File.directory?(git_repo) }
+system "tar -C '#{git_repo}' -xf '#{GIT_TARBALL}'"
+
+# Just FYI, let's show you the checked out git repo.
+puts 'Here is the directory containing the git repository.'
+puts '$ ls -lR'
+system "cd '#{git_repo}/git-repo' && ls -lR"
+
+puts ''
+puts '$ git branch'
+system "cd '#{git_repo}/git-repo' && git branch"
+
+# Set up a logger
+strio = StringIO.new
+logger = Logger.new strio
+
+# To get the catalog differences, call the octocatalog-diff API.
+puts ''
+puts 'Please wait a few seconds for the catalogs to be compiled...'
+result = OctocatalogDiff::API::V1.catalog_diff(
+  basedir: File.join(git_repo, 'git-repo'),
+  to_env: 'test-branch',
+  from_env: 'master',
+  fact_file: FACT_FILE,
+  to_hiera_config: 'config/hiera.yaml', # Relative to the checkout, and only for the "to" catalog
+  to_hiera_path: 'hieradata', # Relative to checkout, and only for the "to" catalog
+  enc: 'config/enc.sh', # Relative to checkout
+  bootstrap_script: 'script/bootstrap.sh', # Relative to checkout
+  node: NODE,
+  puppet_binary: PUPPET_BINARY,
+  ignore: [
+    { type: Regexp.new('\AClass\z'), title: Regexp.new('.*') } # Ignore all type=Class resources
+  ],
+  logger: logger
+)
+
+# Print the log
+puts strio.string
+
+# The `catalog-diff-local-files.rb` example explores the data structures of the
+# return values. Here, simply report on the results.
+
+puts ''
+puts "The from-catalog has #{result.from.resources.size} resources"
+# In the catalog, each resource is a hash, and the keys are strings not symbols.
+result.from.resources.each do |resource|
+  puts "  #{resource['type']}[#{resource['title']}]"
+end
+
+puts "The to-catalog has #{result.to.resources.size} resources"
+result.to.resources.each do |resource|
+  puts "  #{resource['type']}[#{resource['title']}]"
+end
+
+puts "There are #{result.diffs.size} differences"
+
+result.diffs.each do |diff|
+  if diff.addition?
+    puts "Added a #{diff.type} resource called #{diff.title}!"
+  elsif diff.removal?
+    puts "Removed a #{diff.type} resource called #{diff.title}!"
+  elsif diff.change?
+    puts "Changed the #{diff.type} resource #{diff.title} attribute #{diff.structure.join('::')}"
+    puts "   from #{diff.old_value.inspect} to #{diff.new_value.inspect}"
+  else
+    puts 'This is a bug - each entry is an addition, removal, or change.'
+  end
+end

--- a/examples/api/v1/catalog-diff-local-files.rb
+++ b/examples/api/v1/catalog-diff-local-files.rb
@@ -1,0 +1,78 @@
+#!/usr/bin/env ruby
+
+# ------------------------------------------------------------------------------------
+# This is a script that demonstrates the use of the OctocatalogDiff::API::V1.catalog_diff
+# method to compare two catalogs.
+#
+# Run this with:
+#   bundle exec examples/api/v1/catalog-diff-local-files.rb
+#
+# In this example, we'll compare two catalogs.
+# - The "from" catalog will be a catalog that has already been compiled, and exists as a JSON file.
+#   We will use one of the JSON files from the spec fixtures.
+# - The "to" catalog will be compiled using Puppet from one of the spec fixtures.
+#
+# This example will NOT show integration with a git repository. The `catalog-diff-git-repo.rb` file in
+# this directory shows off those features.
+# ------------------------------------------------------------------------------------
+
+# Once you have installed the gem, you want this:
+#
+# require 'octocatalog-diff'
+#
+# To make the script run correctly from within the `examples` directory, this locates
+# the `octocatalog-diff` gem directly from this checkout.
+require_relative '../../../lib/octocatalog-diff'
+
+# Here are a few variables we'll use to compile this catalog. To ensure that this is a
+# working script, it will use resources from the test fixtures. You will need adjust these
+# to the actual values in your application.
+FACT_FILE = File.expand_path('../../../spec/octocatalog-diff/fixtures/facts/facts.yaml', File.dirname(__FILE__))
+HIERA_CONFIG = File.expand_path('../../../spec/octocatalog-diff/fixtures/repos/default/config/hiera.yaml', File.dirname(__FILE__))
+NODE = 'rspec-node.github.net'.freeze
+FROM_CATALOG = File.expand_path('../../../spec/octocatalog-diff/fixtures/catalogs/ignore-tags-new.json', File.dirname(__FILE__))
+PUPPET_REPO = File.expand_path('../../../spec/octocatalog-diff/fixtures/repos/ignore-tags-old', File.dirname(__FILE__))
+PUPPET_BINARY = File.expand_path('../../../script/puppet', File.dirname(__FILE__))
+
+# To get the catalog differences, call the octocatalog-diff API.
+puts 'Please wait a few seconds for the catalogs to be compiled...'
+result = OctocatalogDiff::API::V1.catalog_diff(
+  bootstrapped_to_dir: PUPPET_REPO,
+  fact_file: FACT_FILE,
+  from_catalog: FROM_CATALOG,
+  hiera_config: HIERA_CONFIG,
+  hiera_path: 'hieradata',
+  node: NODE,
+  puppet_binary: PUPPET_BINARY
+)
+
+# We should get back a structure with 3 keys: `:diffs` will be an array of differences; `:from` will be the "from"
+# catalog (which in this case is taken directly from the JSON file), and `:to` will be the "to" catalog (which
+# in this case was compiled). We use 'Openstruct' so that you can treat it as a hash, or as an object with methods.
+puts "Object returned from OctocatalogDiff::API::V1.catalog_diff is: #{result.class}"
+
+# Let's see what kind of objects we have. First, treating the result as a hash:
+puts "The keys are: #{result.to_h.keys.join(', ')}"
+[:diffs, :from, :to].each do |key|
+  puts "result[:#{key}] is a(n) #{result[key].class}"
+end
+
+# We can also use these as methods.
+[:diffs, :from, :to].each do |key|
+  puts "result.#{key} is a(n) #{result.send(key).class}"
+end
+
+# Let's inspect the :diffs array a bit.
+puts "The first element of result.diffs is a(n) #{result.send(:diffs).first.class}"
+puts "There are #{result[:diffs].size} diffs reported here"
+
+# Let's print the first diff in JSON format
+d = result.diffs.first
+puts '--------------------------------------'
+puts 'The first diff is:'
+puts d.inspect
+
+# Internally, the structure of the diff is an array
+puts '--------------------------------------'
+puts 'The raw object format of that diff is:'
+puts d.raw.inspect

--- a/examples/api/v1/catalog-diff-local-files.rb
+++ b/examples/api/v1/catalog-diff-local-files.rb
@@ -43,7 +43,8 @@ result = OctocatalogDiff::API::V1.catalog_diff(
   hiera_config: HIERA_CONFIG,
   hiera_path: 'hieradata',
   node: NODE,
-  puppet_binary: PUPPET_BINARY
+  puppet_binary: PUPPET_BINARY,
+  ignore: { type: '*', title: '*', attr: 'tag' } # Ignore all attributes named 'tag'
 )
 
 # We should get back a structure with 3 keys: `:diffs` will be an array of differences; `:from` will be the "from"

--- a/lib/octocatalog-diff/catalog-diff/differ.rb
+++ b/lib/octocatalog-diff/catalog-diff/differ.rb
@@ -330,7 +330,11 @@ module OctocatalogDiff
         rule = rule_in.dup
 
         # Type matches?
-        return false unless rule[:type] == '*' || rule[:type].casecmp(hsh[:type]).zero?
+        if rule[:type].is_a?(Regexp)
+          return false unless hsh[:type].match(rule[:type])
+        elsif rule[:type].is_a?(String)
+          return false unless rule[:type] == '*' || rule[:type].casecmp(hsh[:type]).zero?
+        end
 
         # Title matches? (Support regexp and string)
         if rule[:title].is_a?(Regexp)

--- a/spec/octocatalog-diff/integration/examples_spec.rb
+++ b/spec/octocatalog-diff/integration/examples_spec.rb
@@ -85,7 +85,7 @@ describe 'examples/api/v1/catalog-diff-local-files.rb' do
       output = @stdout.split("\n")
       expect(output).to include('Object returned from OctocatalogDiff::API::V1.catalog_diff is: OpenStruct')
       expect(output).to include('The keys are: diffs, from, to')
-      expect(output).to include('There are 36 diffs reported here')
+      expect(output).to include('There are 30 diffs reported here')
     end
 
     it 'should not output to STDERR' do

--- a/spec/octocatalog-diff/integration/examples_spec.rb
+++ b/spec/octocatalog-diff/integration/examples_spec.rb
@@ -29,32 +29,104 @@ describe 'examples/octocatalog-diff.cfg.rb' do
 end
 
 describe 'examples/api/v1/catalog-builder-local-files.rb' do
-  let(:script) { File.expand_path('../../../examples/api/v1/catalog-builder-local-files.rb', File.dirname(__FILE__)) }
-  let(:ls_l) { Open3.capture2e("ls -l '#{script}'").first }
+  before(:all) do
+    @script = File.expand_path('../../../examples/api/v1/catalog-builder-local-files.rb', File.dirname(__FILE__))
+  end
 
   it 'should exist' do
-    expect(File.file?(script)).to eq(true), ls_l
+    ls_l = Open3.capture2e("ls -l '#{@script}'").first
+    expect(File.file?(@script)).to eq(true), ls_l
   end
 
   context 'executing' do
-    before(:each) do
-      @stdout_obj = StringIO.new
-      @old_stdout = $stdout
-      $stdout = @stdout_obj
+    before(:all) do
+      @stdout, @stderr, @exitcode = Open3.capture3(@script)
     end
 
-    after(:each) do
-      $stdout = @old_stdout
+    it 'should run without error' do
+      expect(@exitcode.exitstatus).to eq(0)
     end
 
-    it 'should compile and run' do
-      load script
-      output = @stdout_obj.string.split("\n")
+    it 'should print the expected output' do
+      output = @stdout.split("\n")
       expect(output).to include('Object returned from OctocatalogDiff::API::V1.catalog is: OctocatalogDiff::API::V1::Catalog')
       expect(output).to include('The catalog is valid.')
       expect(output).to include('The catalog was built using OctocatalogDiff::Catalog::Computed')
       expect(output).to include('- System::User - bob')
       expect(output).to include('The resources are equal!')
+    end
+
+    it 'should not output to STDERR' do
+      expect(@stderr).to eq('')
+    end
+  end
+end
+
+describe 'examples/api/v1/catalog-diff-local-files.rb' do
+  before(:all) do
+    @script = File.expand_path('../../../examples/api/v1/catalog-diff-local-files.rb', File.dirname(__FILE__))
+  end
+
+  it 'should exist' do
+    ls_l = Open3.capture2e("ls -l '#{@script}'").first
+    expect(File.file?(@script)).to eq(true), ls_l
+  end
+
+  context 'executing' do
+    before(:all) do
+      @stdout, @stderr, @exitcode = Open3.capture3(@script)
+    end
+
+    it 'should run without error' do
+      expect(@exitcode.exitstatus).to eq(0)
+    end
+
+    it 'should print the expected output' do
+      output = @stdout.split("\n")
+      expect(output).to include('Object returned from OctocatalogDiff::API::V1.catalog_diff is: OpenStruct')
+      expect(output).to include('The keys are: diffs, from, to')
+      expect(output).to include('There are 36 diffs reported here')
+    end
+
+    it 'should not output to STDERR' do
+      expect(@stderr).to eq('')
+    end
+  end
+end
+
+describe 'examples/api/v1/catalog-diff-git-repo.rb' do
+  before(:all) do
+    @script = File.expand_path('../../../examples/api/v1/catalog-diff-git-repo.rb', File.dirname(__FILE__))
+  end
+
+  it 'should exist' do
+    ls_l = Open3.capture2e("ls -l '#{@script}'").first
+    expect(File.file?(@script)).to eq(true), ls_l
+  end
+
+  context 'executing' do
+    before(:all) do
+      @stdout, @stderr, @exitcode = Open3.capture3(@script)
+    end
+
+    it 'should run without error' do
+      expect(@exitcode.exitstatus).to eq(0)
+    end
+
+    it 'should print the expected output' do
+      output = @stdout.split("\n")
+      expect(output).to include('Here is the directory containing the git repository.')
+      expect(@stdout).to match(/DEBUG -- : Compiling catalogs for rspec-node.github.net/)
+      expect(@stdout).to match(/Entering catdiff; catalog sizes: 6, 9/)
+      expect(output).to include('The from-catalog has 6 resources')
+      expect(output).to include('The to-catalog has 9 resources')
+      expect(output).to include('There are 6 differences')
+      expect(output).to include('Added a File resource called /tmp/bar!')
+      expect(output).to include('Changed the File resource /tmp/foo attribute parameters::group')
+    end
+
+    it 'should not output to STDERR' do
+      expect(@stderr).to eq('')
     end
   end
 end

--- a/spec/octocatalog-diff/tests/catalog-diff/differ_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-diff/differ_spec.rb
@@ -1210,6 +1210,83 @@ describe OctocatalogDiff::CatalogDiff::Differ do
     end
   end
 
+  describe '#ignore_match?' do
+    let(:resource) { { type: 'Apple', title: 'delicious', attr: "parameters\fcolor" } }
+    let(:testobj) { described_class.allocate }
+
+    context 'type regex' do
+      it 'should filter matching resource' do
+        rule = { type: Regexp.new('A.+e\z'), title: '*', attr: '*' }
+        logger, logger_str = OctocatalogDiff::Spec.setup_logger
+        testobj.instance_variable_set('@logger', logger)
+        expect(testobj.send(:"ignore_match?", rule, '+', resource, 'old_value', 'new_value')).to eq(true)
+        expect(logger_str.string).to match(%r[Ignoring .+ matches {:type=>/A.+e\\z/, :title=>"\*", :attr=>"\*"}])
+      end
+
+      it 'should not filter non-matching resource' do
+        rule = { type: Regexp.new('A.+b\z'), title: '*', attr: '*' }
+        logger, logger_str = OctocatalogDiff::Spec.setup_logger
+        testobj.instance_variable_set('@logger', logger)
+        expect(testobj.send(:"ignore_match?", rule, '+', resource, 'old_value', 'new_value')).to eq(false)
+        expect(logger_str.string).not_to match(%r[Ignoring .+ matches {:type=>/A.+b\\z/, :title=>"\*", :attr=>"\*"}])
+      end
+    end
+
+    context 'type string' do
+      it 'should filter matching resource' do
+        rule = { type: 'Apple', title: '*', attr: '*' }
+        logger, logger_str = OctocatalogDiff::Spec.setup_logger
+        testobj.instance_variable_set('@logger', logger)
+        expect(testobj.send(:"ignore_match?", rule, '+', resource, 'old_value', 'new_value')).to eq(true)
+        expect(logger_str.string).to match(/Ignoring .+ matches {:type=>"Apple", :title=>"\*", :attr=>"\*"}/)
+      end
+
+      it 'should not filter non-matching resource' do
+        rule = { type: 'Banana', title: '*', attr: '*' }
+        logger, logger_str = OctocatalogDiff::Spec.setup_logger
+        testobj.instance_variable_set('@logger', logger)
+        expect(testobj.send(:"ignore_match?", rule, '+', resource, 'old_value', 'new_value')).to eq(false)
+        expect(logger_str.string).not_to match(/Ignoring .+ matches {:type=>"Banana", :title=>"\*", :attr=>"\*"}/)
+      end
+    end
+
+    context 'title regex' do
+      it 'should filter matching resource' do
+        rule = { type: '*', title: Regexp.new('del.+ous'), attr: '*' }
+        logger, logger_str = OctocatalogDiff::Spec.setup_logger
+        testobj.instance_variable_set('@logger', logger)
+        expect(testobj.send(:"ignore_match?", rule, '+', resource, 'old_value', 'new_value')).to eq(true)
+        expect(logger_str.string).to match(%r[Ignoring .+ matches {:type=>"\*", :title=>/del\.\+ous/, :attr=>"\*"}])
+      end
+
+      it 'should not filter non-matching resource' do
+        rule = { type: '*', title: Regexp.new('dell.+ous'), attr: '*' }
+        logger, logger_str = OctocatalogDiff::Spec.setup_logger
+        testobj.instance_variable_set('@logger', logger)
+        expect(testobj.send(:"ignore_match?", rule, '+', resource, 'old_value', 'new_value')).to eq(false)
+        expect(logger_str.string).not_to match(%r[Ignoring .+ matches {:type=>"\*", :title=>/dell\.\+ous/, :attr=>"\*"}])
+      end
+    end
+
+    context 'title string' do
+      it 'should filter matching resource' do
+        rule = { type: '*', title: 'delicious', attr: '*' }
+        logger, logger_str = OctocatalogDiff::Spec.setup_logger
+        testobj.instance_variable_set('@logger', logger)
+        expect(testobj.send(:"ignore_match?", rule, '+', resource, 'old_value', 'new_value')).to eq(true)
+        expect(logger_str.string).to match(/Ignoring .+ matches {:type=>"\*", :title=>"delicious", :attr=>"\*"}/)
+      end
+
+      it 'should not filter non-matching resource' do
+        rule = { type: '*', title: 'dell', attr: '*' }
+        logger, logger_str = OctocatalogDiff::Spec.setup_logger
+        testobj.instance_variable_set('@logger', logger)
+        expect(testobj.send(:"ignore_match?", rule, '+', resource, 'old_value', 'new_value')).to eq(false)
+        expect(logger_str.string).not_to match(/Ignoring .+ matches {:type=>"\*", :title=>"dell", :attr=>"\*"}/)
+      end
+    end
+  end
+
   describe '#hashdiff_nested_changes' do
     it 'should return array with proper results' do
       hashdiff_add_remove = [


### PR DESCRIPTION
Add example scripts for catalog-diff API.

Also, to match documentation, support regexp for type matches.