### PR TITLE
Move ignore tagged resources out of CLI

### DIFF
--- a/lib/octocatalog-diff/cli/diffs.rb
+++ b/lib/octocatalog-diff/cli/diffs.rb
@@ -28,51 +28,12 @@ module OctocatalogDiff
         differ = OctocatalogDiff::CatalogDiff::Differ.new(diff_opts, catalogs[:from], catalogs[:to])
         differ.ignore(attr: 'tags') unless @options.fetch(:include_tags, false)
         differ.ignore(@options.fetch(:ignore, []))
-
-        # Handle --ignore-tags option, the ability to tag resources within modules/manifests and
-        # have catalog-diff ignore them.
-        if @options[:ignore_tags].is_a?(Array) && @options[:ignore_tags].any?
-          # Go through the "to" catalog and identify any resources that have been tagged with one or more
-          # specified "ignore tags." Add any such items to the ignore list. The 'to' catalog has the authoritative
-          # list of dynamic ignores.
-          catalogs[:to].resources.each do |resource|
-            next unless tagged_for_ignore?(resource)
-            differ.ignore(type: resource['type'], title: resource['title'])
-            @logger.debug "Ignoring type='#{resource['type']}', title='#{resource['title']}' based on tag in to-catalog"
-          end
-
-          # Go through the "from" catalog and identify any resources that have been tagged with one or more
-          # specified "ignore tags." Only mark the resources for ignoring if they do not appear in the 'to'
-          # catalog, thereby allowing the 'to' catalog to be the authoritative ignore list. This allows deleted
-          # items that were previously ignored to continue to be ignored.
-          catalogs[:from].resources.each do |resource|
-            next if catalogs[:to].resource(type: resource['type'], title: resource['title'])
-            next unless tagged_for_ignore?(resource)
-            differ.ignore(type: resource['type'], title: resource['title'])
-            @logger.debug "Ignoring type='#{resource['type']}', title='#{resource['title']}' based on tag in from-catalog"
-          end
-        end
+        differ.ignore_tags
 
         # Actually perform the diff
         diff_result = differ.diff
         @logger.debug 'Success compute diffs between catalogs'
         diff_result
-      end
-
-      private
-
-      # Determine if a resource is tagged with any ignore-tag.
-      # @param resource [Hash] The resource
-      # @return [Boolean] true if tagged for ignore, false if not
-      def tagged_for_ignore?(resource)
-        return false unless @options[:ignore_tags].is_a?(Array)
-        return false unless resource.key?('tags') && resource['tags'].is_a?(Array)
-        @options[:ignore_tags].each do |tag|
-          # tag_with_type will be like: 'ignored_catalog_diff__mymodule__mytype'
-          tag_with_type = [tag, resource['type'].downcase.gsub(/\W/, '_')].join('__')
-          return true if resource['tags'].include?(tag) || resource['tags'].include?(tag_with_type)
-        end
-        false
       end
     end
   end

--- a/spec/octocatalog-diff/integration/ignore_tags_spec.rb
+++ b/spec/octocatalog-diff/integration/ignore_tags_spec.rb
@@ -98,4 +98,21 @@ describe 'ignore-tags integration' do
       end
     end
   end
+
+  it 'should remove tagged-for-ignore resources' do
+    @logger, @logger_str = OctocatalogDiff::Spec.setup_logger
+    cat1 = OctocatalogDiff::Catalog.new(json: File.read(OctocatalogDiff::Spec.fixture_path('catalogs/ignore-tags-old.json')))
+    cat2 = OctocatalogDiff::Catalog.new(json: File.read(OctocatalogDiff::Spec.fixture_path('catalogs/ignore-tags-new.json')))
+    opts = { ignore_tags: ['ignored_catalog_diff'] }
+    answer = JSON.parse(File.read(OctocatalogDiff::Spec.fixture_path('diffs/ignore-tags-partial.json')))
+    obj = OctocatalogDiff::Cli::Diffs.new(opts, @logger)
+    diffs = obj.diffs(from: cat1, to: cat2)
+    expect(diffs.size).to eq(8)
+    answer.each do |x|
+      expect(diffs).to include(x), "Does not contain: #{x}"
+    end
+    expect(@logger_str.string).to match(/Ignoring type='Mymodule::Resource1', title='one' based on tag in to-catalog/)
+    r = %r{Ignoring type='File', title='/tmp/old-file/ignored/one' based on tag in from-catalog}
+    expect(@logger_str.string).to match(r)
+  end
 end

--- a/spec/octocatalog-diff/tests/cli/diffs_spec.rb
+++ b/spec/octocatalog-diff/tests/cli/diffs_spec.rb
@@ -67,21 +67,5 @@ describe OctocatalogDiff::Cli::Diffs do
       expect(result).to eq([])
       expect(@logger_str.string).not_to match(/WARN/)
     end
-
-    it 'should remove tagged-for-ignore resources' do
-      cat1 = OctocatalogDiff::Catalog.new(json: File.read(OctocatalogDiff::Spec.fixture_path('catalogs/ignore-tags-old.json')))
-      cat2 = OctocatalogDiff::Catalog.new(json: File.read(OctocatalogDiff::Spec.fixture_path('catalogs/ignore-tags-new.json')))
-      opts = { ignore_tags: ['ignored_catalog_diff'] }
-      answer = JSON.parse(File.read(OctocatalogDiff::Spec.fixture_path('diffs/ignore-tags-partial.json')))
-      obj = OctocatalogDiff::Cli::Diffs.new(opts, @logger)
-      diffs = obj.diffs(from: cat1, to: cat2)
-      expect(diffs.size).to eq(8)
-      answer.each do |x|
-        expect(diffs).to include(x), "Does not contain: #{x}"
-      end
-      expect(@logger_str.string).to match(/Ignoring type='Mymodule::Resource1', title='one' based on tag in to-catalog/)
-      r = %r{Ignoring type='File', title='/tmp/old-file/ignored/one' based on tag in from-catalog}
-      expect(@logger_str.string).to match(r)
-    end
   end
 end


### PR DESCRIPTION
This PR moves the "ignore tagged resources" [Dynamic Ignoring Based On Tags](https://github.com/github/octocatalog-diff/blob/884a6f683c7f9038c5160441dc9fc141a72e1fac/doc/advanced-dynamic-ignores.md) out of the CLI class so it's usable via the API.