### PR TITLE
Filter validation

### DIFF
--- a/lib/octocatalog-diff/catalog-diff/filter.rb
+++ b/lib/octocatalog-diff/catalog-diff/filter.rb
@@ -10,6 +10,24 @@ module OctocatalogDiff
     class Filter
       attr_accessor :logger
 
+      # List the available filters here (by class name) for use in the validator method.
+      AVAILABLE_FILTERS = %w(AbsentFile CompilationDir YAML).freeze
+
+      # Public: Determine whether a particular filter exists. This can be used to validate
+      # a user-submitted filter.
+      # @param filter_name [String] Proposed filter name
+      # @return [Boolean] True if filter is valid; false otherwise
+      def self.filter?(filter_name)
+        AVAILABLE_FILTERS.include?(filter_name)
+      end
+
+      # Public: Assert that a filter exists, and raise an error if it does not.
+      # @param filter_name [String] Proposed filter name
+      def self.assert_that_filter_exists(filter_name)
+        return if filter?(filter_name)
+        raise ArgumentError, "The filter #{filter_name} is not valid"
+      end
+
       # Public: Apply multiple filters by repeatedly calling the `filter` method for each
       # filter in an array. This method returns nothing.
       #
@@ -29,6 +47,7 @@ module OctocatalogDiff
       # @param filter_class_name [String] Filter class name (from `filter` subdirectory)
       # @param options [Hash] Additional options (optional) to pass to filtered? method
       def self.filter(result, filter_class_name, options = {})
+        assert_that_filter_exists(filter_class_name)
         filter_class_name = [name.to_s, filter_class_name].join('::')
         obj = Kernel.const_get(filter_class_name).new(result, options[:logger])
         result.reject! { |item| obj.filtered?(item, options) }

--- a/lib/octocatalog-diff/cli/options/filters.rb
+++ b/lib/octocatalog-diff/cli/options/filters.rb
@@ -12,6 +12,9 @@ OctocatalogDiff::Cli::Options::Option.newoption(:filters) do
     parser.on('--filters FILTER1[,FILTER2[,...]]', Array, 'Filters to apply') do |x|
       options[:filters] ||= []
       options[:filters].concat x
+
+      require_relative '../../catalog-diff/filter'
+      options[:filters].each { |filter| OctocatalogDiff::CatalogDiff::Filter.assert_that_filter_exists(filter) }
     end
   end
 end

--- a/spec/octocatalog-diff/tests/cli/options/filters_spec.rb
+++ b/spec/octocatalog-diff/tests/cli/options/filters_spec.rb
@@ -5,13 +5,19 @@ require_relative '../options_helper'
 describe OctocatalogDiff::Cli::Options do
   describe '#opt_ignore_equivalent_yaml_files' do
     it 'should accept comma delimited parameters for --filters' do
-      result = run_optparse(['--filters', 'fizzbuzz,barbuzz'])
-      expect(result[:filters]).to eq(%w(fizzbuzz barbuzz))
+      result = run_optparse(['--filters', 'AbsentFile,YAML'])
+      expect(result[:filters]).to eq(%w(AbsentFile YAML))
     end
 
     it 'should accept multiple parameters for --filters' do
-      result = run_optparse(['--filters', 'fizzbuzz', '--filters', 'barbuzz'])
-      expect(result[:filters]).to eq(%w(fizzbuzz barbuzz))
+      result = run_optparse(['--filters', 'AbsentFile', '--filters', 'YAML'])
+      expect(result[:filters]).to eq(%w(AbsentFile YAML))
+    end
+
+    it 'should raise ArgumentError if invalid filter is specified' do
+      expect do
+        run_optparse(['--filters', 'AbsentFile,FizzBuzzDoesNotExist,YAML'])
+      end.to raise_error(ArgumentError, 'The filter FizzBuzzDoesNotExist is not valid')
     end
   end
 end


### PR DESCRIPTION
Ensure that any user-provided filter names actually exist. Raise a more immediate and less cryptic error if they don't.