### PR TITLE
Add missing []= method

### DIFF
--- a/lib/octocatalog-diff/api/v1/diff.rb
+++ b/lib/octocatalog-diff/api/v1/diff.rb
@@ -49,6 +49,12 @@ module OctocatalogDiff
           @raw[i]
         end
 
+        # Public: Set an element of the array
+        # @param [new_value] The value to set it to
+        def []=(i, new_value)
+          @raw[i] = new_value
+        end
+
         # Public: Is this an addition?
         # @return [Boolean] True if this is an addition
         def addition?

--- a/spec/octocatalog-diff/tests/api/v1/diff_spec.rb
+++ b/spec/octocatalog-diff/tests/api/v1/diff_spec.rb
@@ -45,7 +45,7 @@ describe OctocatalogDiff::API::V1::Diff do
   describe '#[]=' do
     it 'should set values in the array' do
       testobj = described_class.new(chg_1)
-      testobj[3]='newer'
+      testobj[3] = 'newer'
       expect(testobj.new_value).to eq('newer')
     end
   end

--- a/spec/octocatalog-diff/tests/api/v1/diff_spec.rb
+++ b/spec/octocatalog-diff/tests/api/v1/diff_spec.rb
@@ -42,6 +42,14 @@ describe OctocatalogDiff::API::V1::Diff do
     end
   end
 
+  describe '#[]=' do
+    it 'should set values in the array' do
+      testobj = described_class.new(chg_1)
+      testobj[3]='newer'
+      expect(testobj.new_value).to eq('newer')
+    end
+  end
+
   describe '#diff_type' do
     it 'should identify the symbol' do
       testobj = described_class.new(chg_2)


### PR DESCRIPTION
<!--
Hi there! We are delighted that you have chosen to contribute to octocatalog-diff.

If you have not already done so, please read our Contributing document, found here: https://github.com/github/octocatalog-diff/blob/master/.github/CONTRIBUTING.md

Please remember that all activity in this project, including pull requests, needs to comply with the Open Code of Conduct, found here: http://todogroup.org/opencodeofconduct/

Any contributions to this project must be made under the MIT license.

You do NOT need to bump the version number or regenerate the "Command line options reference" page. We will do this for you at or after the time we merge your contribution.
-->

## Overview

This pull request defines the `[]=` method in the `Api::V1::Diff` class.

The method is already called from different parts of the code (eg https://github.com/github/octocatalog-diff/blob/384085155a5324384638ceb6737b24698e758ba2/lib/octocatalog-diff/catalog-diff/display/text.rb#L401-L402), that fail when exercised.

## Checklist

- [x] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [x] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [x] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended.
- [x] If you have added any new gem dependencies, make sure those gems are licensed under the MIT or Apache 2.0 license. We cannot add any dependencies on gems licensed under GPL.
- [x] If you have added any new gem dependencies, make sure you've checked in a copy of the `.gem` file into the [vendor/cache](https://github.com/github/octocatalog-diff/tree/master/vendor/cache) directory.

/cc @kpaulisse 