### PR TITLE
Integration refactors - exit codes, more information

### DIFF
--- a/lib/octocatalog-diff/cli.rb
+++ b/lib/octocatalog-diff/cli.rb
@@ -116,8 +116,8 @@ module OctocatalogDiff
       printer_obj = OctocatalogDiff::Cli::Printer.new(options, logger)
       printer_obj.printer(diffs, catalog_diff.from.compilation_dir, catalog_diff.to.compilation_dir)
 
-      # Return the diff object if requested (generally for testing) or otherwise return exit code
-      return diffs if opts[:RETURN_DIFFS]
+      # Return the resulting diff object if requested (generally for testing) or otherwise return exit code
+      return catalog_diff if opts[:INTEGRATION]
       diffs.any? ? EXITCODE_SUCCESS_WITH_DIFFS : EXITCODE_SUCCESS_NO_DIFFS
     end
 
@@ -169,11 +169,8 @@ module OctocatalogDiff
         puts to_catalog.to_json
       end
 
-      return EXITCODE_SUCCESS_NO_DIFFS unless options[:RETURN_DIFFS] # For integration testing
-      # :nocov:
-      dummy_catalog = OctocatalogDiff::API::V1::Catalog.new(OctocatalogDiff::Catalog.new(backend: :noop))
-      [dummy_catalog, to_catalog]
-      # :nocov:
+      return { exitcode: EXITCODE_SUCCESS_NO_DIFFS, to: to_catalog } if options[:INTEGRATION] # For integration testing
+      EXITCODE_SUCCESS_NO_DIFFS
     end
 
     # --bootstrap-then-exit command

--- a/spec/octocatalog-diff/integration/catalog_only_spec.rb
+++ b/spec/octocatalog-diff/integration/catalog_only_spec.rb
@@ -26,25 +26,18 @@ describe 'a catalog-only operation' do
 
   it 'should compile the catalog' do
     expect(@result[:exitcode]).not_to eq(-1), OctocatalogDiff::Integration.format_exception(@result)
-    expect(@result[:exitcode]).to eq(2), "Runtime error: #{@result[:logs]}"
-  end
-
-  it 'should set the from-catalog to a no-op catalog type' do
-    pending 'catalog compilation failed' unless @result[:exitcode] == 2
-    from_catalog = @result[:diffs][0]
-    expect(from_catalog).to be_a_kind_of(OctocatalogDiff::API::V1::Catalog)
-    expect(from_catalog.builder).to eq('OctocatalogDiff::Catalog::Noop')
+    expect(@result[:exitcode]).to eq(0), "Runtime error: #{@result[:logs]}"
   end
 
   it 'should set the to-catalog to a computed catalog type' do
-    pending 'catalog compilation failed' unless @result[:exitcode] == 2
-    to_catalog = @result[:diffs][1]
+    pending 'catalog compilation failed' unless (@result[:exitcode]).zero?
+    to_catalog = @result.to
     expect(to_catalog).to be_a_kind_of(OctocatalogDiff::API::V1::Catalog)
     expect(to_catalog.builder).to eq('OctocatalogDiff::Catalog::Computed')
   end
 
   it 'should have log messages indicating catalog compilations' do
-    pending 'catalog compilation failed' unless @result[:exitcode] == 2
+    pending 'catalog compilation failed' unless (@result[:exitcode]).zero?
     logs = @result[:logs]
     expect(logs).to match(/Compiling catalog for rspec-node.github.net/)
     expect(logs).to match(/Initialized OctocatalogDiff::Catalog::Noop for from-catalog/)
@@ -52,8 +45,8 @@ describe 'a catalog-only operation' do
   end
 
   it 'should produce a valid catalog' do
-    pending 'catalog compilation failed' unless @result[:exitcode] == 2
-    to_catalog = @result[:diffs][1]
+    pending 'catalog compilation failed' unless (@result[:exitcode]).zero?
+    to_catalog = @result.to
     expect(to_catalog.valid?).to eq(true)
     expect(to_catalog.to_h).to be_a_kind_of(Hash)
     expect(to_catalog.to_json).to be_a_kind_of(String)
@@ -61,8 +54,8 @@ describe 'a catalog-only operation' do
   end
 
   it 'should produce the expected catalog' do
-    pending 'catalog compilation failed' unless @result[:exitcode] == 2
-    to_catalog = @result[:diffs][1]
+    pending 'catalog compilation failed' unless @result.exitcode.zero?
+    to_catalog = @result.to
 
     param1 = { 'owner' => 'root', 'group' => 'root', 'mode' => '0644', 'content' => 'Testy McTesterson' }
     expect(to_catalog.resource(type: 'File', title: '/tmp/foo')['parameters']).to eq(param1)

--- a/spec/octocatalog-diff/integration/reference_validation_spec.rb
+++ b/spec/octocatalog-diff/integration/reference_validation_spec.rb
@@ -45,7 +45,7 @@ describe 'validation specifically disabled' do
   end
 
   it 'should return the valid catalog' do
-    expect(@result.exitcode).to eq(2), OctocatalogDiff::Integration.format_exception(@result)
+    expect(@result.exitcode).to eq(0), OctocatalogDiff::Integration.format_exception(@result)
   end
 end
 
@@ -55,7 +55,7 @@ describe 'validation of sample catalog' do
   end
 
   it 'should return the valid catalog' do
-    expect(@result.exitcode).to eq(2)
+    expect(@result.exitcode).to eq(0)
   end
 
   it 'should not raise any exceptions' do
@@ -63,7 +63,7 @@ describe 'validation of sample catalog' do
   end
 
   it 'should contain representative resources' do
-    pending 'Catalog failed' unless @result.exitcode == 2
+    pending 'Catalog failed' unless @result.exitcode.zero?
     expect(OctocatalogDiff::Spec.catalog_contains_resource(@result, 'File', '/tmp/test-main')).to eq(true)
   end
 end
@@ -75,7 +75,7 @@ describe 'validation of references in computed catalog' do
     end
 
     it 'should succeed' do
-      expect(@result.exitcode).to eq(2)
+      expect(@result.exitcode).to eq(0)
     end
 
     it 'should not raise any exceptions' do
@@ -83,7 +83,7 @@ describe 'validation of references in computed catalog' do
     end
 
     it 'should contain representative resources' do
-      pending 'Catalog failed' unless @result.exitcode == 2
+      pending 'Catalog failed' unless @result.exitcode.zero?
       expect(OctocatalogDiff::Spec.catalog_contains_resource(@result, 'Exec', 'subscribe caller 1')).to eq(true)
       expect(OctocatalogDiff::Spec.catalog_contains_resource(@result, 'Exec', 'subscribe target')).to eq(true)
     end
@@ -179,7 +179,7 @@ describe 'validation of references in computed catalog' do
     end
 
     it 'should succeed' do
-      expect(@result.exitcode).to eq(2), OctocatalogDiff::Integration.format_exception(@result)
+      expect(@result.exitcode).to eq(0), OctocatalogDiff::Integration.format_exception(@result)
     end
 
     it 'should not raise error' do
@@ -195,7 +195,7 @@ describe 'validation of alias references' do
     end
 
     it 'should succeed' do
-      expect(@result.exitcode).to eq(2)
+      expect(@result.exitcode).to eq(0)
     end
 
     it 'should not raise any exceptions' do
@@ -203,7 +203,7 @@ describe 'validation of alias references' do
     end
 
     it 'should contain representative resources' do
-      pending 'Catalog failed' unless @result.exitcode == 2
+      pending 'Catalog failed' unless @result.exitcode.zero?
       expect(OctocatalogDiff::Spec.catalog_contains_resource(@result, 'Exec', 'before alias caller')).to eq(true)
       expect(OctocatalogDiff::Spec.catalog_contains_resource(@result, 'Exec', 'before alias target')).to eq(true)
       expect(OctocatalogDiff::Spec.catalog_contains_resource(@result, 'Exec', 'the before alias target')).to eq(true)


### PR DESCRIPTION
This PR updates some of the integration logic to return additional details for analysis. For example a catalog-diff result will now make both catalogs available for further testing.

Also, make the exit status for `--catalog-only` consistent with the CLI. 0 = success, 1 = not.

/cc https://github.com/github/octocatalog-diff/pull/74 since some of the work was originally done there.