### PR TITLE
Whitespace diff display

### DIFF
--- a/lib/octocatalog-diff/catalog-diff/display/text.rb
+++ b/lib/octocatalog-diff/catalog-diff/display/text.rb
@@ -260,8 +260,7 @@ module OctocatalogDiff
           # Single line strings?
           if single_lines?(string1, string2)
             string1, string2 = add_trailing_newlines(string1, string2)
-            diff = Diffy::Diff.new(string1, string2, context: 2, include_diff_info: true).to_s.split("\n")
-            3.times { diff.shift }
+            diff = Diffy::Diff.new(string1, string2, context: 2, include_diff_info: false).to_s.split("\n")
             return diff.map { |x| left_pad(2 * depth + 2, make_trailing_whitespace_visible(adjust_position_of_plus_minus(x))) }
           end
 

--- a/lib/octocatalog-diff/catalog-diff/display/text.rb
+++ b/lib/octocatalog-diff/catalog-diff/display/text.rb
@@ -319,9 +319,9 @@ module OctocatalogDiff
             if nested && obj[:old].is_a?(Hash) && obj[:new].is_a?(Hash)
               # Nested hashes will be stringified and then use 'diffy'
               result.concat diff_two_hashes_with_diffy(depth: depth, hash1: obj[:old], hash2: obj[:new])
-            elsif obj[:old].is_a?(String) && obj[:new].is_a?(String) && (obj[:old] =~ /\n/ || obj[:new] =~ /\n/)
-              # Multi-line strings will be split and then use 'diffy' to mimic the
-              # output seen when using "diff" on the command line
+            elsif obj[:old].is_a?(String) && obj[:new].is_a?(String)
+              # Strings will use 'diffy' to mimic the output seen when using
+              # "diff" on the command line.
               result.concat diff_two_strings_with_diffy(obj[:old], obj[:new], depth)
             else
               # Stuff we don't recognize will be converted to a string and printed

--- a/lib/octocatalog-diff/catalog-diff/display/text.rb
+++ b/lib/octocatalog-diff/catalog-diff/display/text.rb
@@ -257,13 +257,68 @@ module OctocatalogDiff
         # @param depth [Fixnum] Depth, for correct indentation
         # @return Array<String> Displayable result
         def self.diff_two_strings_with_diffy(string1, string2, depth)
-          # prevent 'No newline at end of file' for single line strings
-          string1 += "\n" unless string1 =~ /\n/
-          string2 += "\n" unless string2 =~ /\n/
+          # Single line strings?
+          if single_lines?(string1, string2)
+            string1, string2 = add_trailing_newlines(string1, string2)
+            diff = Diffy::Diff.new(string1, string2, context: 2, include_diff_info: true).to_s.split("\n")
+            3.times { diff.shift }
+            return diff.map { |x| left_pad(2 * depth + 2, make_trailing_whitespace_visible(adjust_position_of_plus_minus(x))) }
+          end
+
+          # Multiple line strings
+          string1, string2 = add_trailing_newlines(string1, string2)
           diff = Diffy::Diff.new(string1, string2, context: 2, include_diff_info: true).to_s.split("\n")
           diff.shift # Remove first line of diff info (filename that makes no sense)
           diff.shift # Remove second line of diff info (filename that makes no sense)
-          diff.map { |x| left_pad(2 * depth + 2, x) }
+          diff.map { |x| left_pad(2 * depth + 2, make_trailing_whitespace_visible(x)) }
+        end
+
+        # Determine if two incoming strings are single lines. Returns true if both
+        # incoming strings are single lines, false otherwise.
+        # @param string_1 [String] First string
+        # @param string_2 [String] Second string
+        # @return [Boolean] Whether both incoming strings are single lines
+        def self.single_lines?(string_1, string_2)
+          string_1.strip !~ /\n/ && string_2.strip !~ /\n/
+        end
+
+        # Add "\n" to the end of both strings, only if both strings are lacking it.
+        # This prevents "\\ No newline at end of file" for single string comparison.
+        # @param string_1 [String] First string
+        # @param string_2 [String] Second string
+        # @return [Array<String>] Adjusted string_1, string_2
+        def self.add_trailing_newlines(string_1, string_2)
+          return [string_1, string_2] unless string_1 !~ /\n\Z/ && string_2 !~ /\n\Z/
+          [string_1 + "\n", string_2 + "\n"]
+        end
+
+        # Adjust the space after of the `-` / `+` in the diff for single line diffs.
+        # Diffy prints diffs with no space between the `-` / `+` in the text, but for
+        # single lines it's easier to read with that space added.
+        # @param string_in [String] Input string, which is a line of a diff from diffy
+        # @return [String] Modified string
+        def self.adjust_position_of_plus_minus(string_in)
+          string_in.sub(/\A(\e\[\d+m)?([\-\+])/, '\1\2 ')
+        end
+
+        # Convert trailing whitespace to underscore for display purposes. Also convert special
+        # whitespace (\r, \n, \t, ...) to character representation.
+        # @param string_in [String] Input string, which might contain trailing whitespace
+        # @return [String] Modified string
+        def self.make_trailing_whitespace_visible(string_in)
+          return string_in unless string_in =~ /\A((?:.|\n)*?)(\s+)(\e\[0m)?\Z/
+          beginning = Regexp.last_match(1)
+          trailing_space = Regexp.last_match(2)
+          end_escape = Regexp.last_match(3)
+
+          # Trailing space adjustment for line endings
+          trailing_space.gsub! "\n", '\n'
+          trailing_space.gsub! "\r", '\r'
+          trailing_space.gsub! "\t", '\t'
+          trailing_space.gsub! "\f", '\f'
+          trailing_space.tr! ' ', '_'
+
+          [beginning, trailing_space, end_escape].join('')
         end
 
         # Get the diff of two hashes. Call the 'diffy' gem for this.

--- a/spec/octocatalog-diff/integration/text_diff_spec.rb
+++ b/spec/octocatalog-diff/integration/text_diff_spec.rb
@@ -1,0 +1,288 @@
+# frozen_string_literal: true
+
+require_relative '../tests/spec_helper'
+
+require OctocatalogDiff::Spec.require_path('catalog')
+require OctocatalogDiff::Spec.require_path('catalog-diff/differ')
+require OctocatalogDiff::Spec.require_path('catalog-diff/display')
+
+require 'json'
+
+describe 'text diff display for whitespace' do
+  let(:base_catalog) do
+    {
+      'resources' => [
+        {
+          'type'       => 'File',
+          'title'      => '/tmp/foo',
+          'parameters' => { 'content' => 'THIS SHOULD BE OVERRIDDEN' }
+        }
+      ]
+    }
+  end
+
+  let(:display_opts) { { format: :text } }
+  let(:logger) { OctocatalogDiff::Spec.setup_logger.first }
+  let(:diff_opts) { { logger: logger } }
+
+  def build_catalog(hash_in, string_in)
+    hash_in['resources'].first['parameters']['content'] = string_in
+    OctocatalogDiff::Catalog.new(json: JSON.generate(hash_in))
+  end
+
+  context 'single line identical' do
+    it 'should display no diffs at all' do
+      catalog1 = build_catalog(base_catalog, 'file line')
+      catalog2 = build_catalog(base_catalog, 'file line')
+      diff = OctocatalogDiff::CatalogDiff::Differ.new(diff_opts, catalog1, catalog2)
+      result = OctocatalogDiff::CatalogDiff::Display.output(diff, display_opts, logger)
+      answer = []
+      expect(result).to eq(answer)
+    end
+  end
+
+  context 'single lines with different newlines' do
+    it 'should display newline message when newline exists in old' do
+      catalog1 = build_catalog(base_catalog, "file line\n")
+      catalog2 = build_catalog(base_catalog, 'file line')
+      diff = OctocatalogDiff::CatalogDiff::Differ.new(diff_opts, catalog1, catalog2)
+      result = OctocatalogDiff::CatalogDiff::Display.output(diff, display_opts, logger)
+      answer = [
+        '  File[/tmp/foo] =>',
+        '   parameters =>',
+        '     content =>',
+        '      - file line',
+        '      + file line',
+        '      \\ No newline at end of file',
+        '*******************************************'
+      ]
+      expect(result).to eq(answer)
+    end
+
+    it 'should display newline message when newline exists in new' do
+      catalog1 = build_catalog(base_catalog, 'file line')
+      catalog2 = build_catalog(base_catalog, "file line\n")
+      diff = OctocatalogDiff::CatalogDiff::Differ.new(diff_opts, catalog1, catalog2)
+      result = OctocatalogDiff::CatalogDiff::Display.output(diff, display_opts, logger)
+      answer = [
+        '  File[/tmp/foo] =>',
+        '   parameters =>',
+        '     content =>',
+        '      - file line',
+        '      \\ No newline at end of file',
+        '      + file line',
+        '*******************************************'
+      ]
+      expect(result).to eq(answer)
+    end
+  end
+
+  context 'single line vs. multiple line' do
+    it 'should display newline message for old' do
+      catalog1 = build_catalog(base_catalog, 'file line')
+      catalog2 = build_catalog(base_catalog, "file line\nfile line\n")
+      diff = OctocatalogDiff::CatalogDiff::Differ.new(diff_opts, catalog1, catalog2)
+      result = OctocatalogDiff::CatalogDiff::Display.output(diff, display_opts, logger)
+      answer = [
+        '  File[/tmp/foo] =>',
+        '   parameters =>',
+        '     content =>',
+        '      @@ -1 +1,2 @@',
+        '      -file line',
+        '      \\ No newline at end of file',
+        '      +file line',
+        '      +file line',
+        '*******************************************'
+      ]
+      expect(result).to eq(answer)
+    end
+  end
+
+  context 'multiple lines with different newlines' do
+    it 'should display newline message when newline exists in old' do
+      catalog1 = build_catalog(base_catalog, "file line\nfile line\n")
+      catalog2 = build_catalog(base_catalog, "file line\nfile line")
+      diff = OctocatalogDiff::CatalogDiff::Differ.new(diff_opts, catalog1, catalog2)
+      result = OctocatalogDiff::CatalogDiff::Display.output(diff, display_opts, logger)
+      answer = [
+        '  File[/tmp/foo] =>',
+        '   parameters =>',
+        '     content =>',
+        '      @@ -1,2 +1,2 @@',
+        '       file line',
+        '      -file line',
+        '      +file line',
+        '      \\ No newline at end of file',
+        '*******************************************'
+      ]
+      expect(result).to eq(answer)
+    end
+
+    it 'should display newline message when newline exists in new' do
+      catalog1 = build_catalog(base_catalog, "file line\nfile line")
+      catalog2 = build_catalog(base_catalog, "file line\nfile line\n")
+      diff = OctocatalogDiff::CatalogDiff::Differ.new(diff_opts, catalog1, catalog2)
+      result = OctocatalogDiff::CatalogDiff::Display.output(diff, display_opts, logger)
+      answer = [
+        '  File[/tmp/foo] =>',
+        '   parameters =>',
+        '     content =>',
+        '      @@ -1,2 +1,2 @@',
+        '       file line',
+        '      -file line',
+        '      \\ No newline at end of file',
+        '      +file line',
+        '*******************************************'
+      ]
+      expect(result).to eq(answer)
+    end
+  end
+
+  context 'both multi-line strings do not end in newline' do
+    it 'should display differences but no newline alert' do
+      catalog1 = build_catalog(base_catalog, "file line\nold line\nlast line")
+      catalog2 = build_catalog(base_catalog, "file line\nnew line\nlast line")
+      diff = OctocatalogDiff::CatalogDiff::Differ.new(diff_opts, catalog1, catalog2)
+      result = OctocatalogDiff::CatalogDiff::Display.output(diff, display_opts, logger)
+      answer = [
+        '  File[/tmp/foo] =>',
+        '   parameters =>',
+        '     content =>',
+        '      @@ -1,3 +1,3 @@',
+        '       file line',
+        '      -old line',
+        '      +new line',
+        '       last line',
+        '*******************************************'
+      ]
+      expect(result).to eq(answer)
+    end
+  end
+
+  context 'different line endings' do
+    it 'should handle windows vs. unix' do
+      catalog1 = build_catalog(base_catalog, "file line\r\nline two\r\nline three\r\n")
+      catalog2 = build_catalog(base_catalog, "file line\nline two\nline three\n")
+      diff = OctocatalogDiff::CatalogDiff::Differ.new(diff_opts, catalog1, catalog2)
+      result = OctocatalogDiff::CatalogDiff::Display.output(diff, display_opts, logger)
+      answer = [
+        '  File[/tmp/foo] =>',
+        '   parameters =>',
+        '     content =>',
+        '      @@ -1,3 +1,3 @@',
+        '      -file line\\r',
+        '      -line two\\r',
+        '      -line three\\r',
+        '      +file line',
+        '      +line two',
+        '      +line three',
+        '*******************************************'
+      ]
+      expect(result).to eq(answer)
+    end
+  end
+
+  context 'whitespace on single line' do
+    it 'should display proper diffs for leading whitespace difference' do
+      catalog1 = build_catalog(base_catalog, '    file line')
+      catalog2 = build_catalog(base_catalog, 'file line')
+      diff = OctocatalogDiff::CatalogDiff::Differ.new(diff_opts, catalog1, catalog2)
+      result = OctocatalogDiff::CatalogDiff::Display.output(diff, display_opts, logger)
+      answer = [
+        '  File[/tmp/foo] =>',
+        '   parameters =>',
+        '     content =>',
+        '      -     file line',
+        '      + file line',
+        '*******************************************'
+      ]
+      expect(result).to eq(answer)
+    end
+
+    it 'should display proper diffs for trailing whitespace difference' do
+      catalog1 = build_catalog(base_catalog, 'file line    ')
+      catalog2 = build_catalog(base_catalog, 'file line')
+      diff = OctocatalogDiff::CatalogDiff::Differ.new(diff_opts, catalog1, catalog2)
+      result = OctocatalogDiff::CatalogDiff::Display.output(diff, display_opts, logger)
+      answer = [
+        '  File[/tmp/foo] =>',
+        '   parameters =>',
+        '     content =>',
+        '      - file line____',
+        '      + file line',
+        '*******************************************'
+      ]
+      expect(result).to eq(answer)
+    end
+
+    it 'should display proper diffs for trailing whitespace size difference' do
+      catalog1 = build_catalog(base_catalog, 'file line    ')
+      catalog2 = build_catalog(base_catalog, 'file line   ')
+      diff = OctocatalogDiff::CatalogDiff::Differ.new(diff_opts, catalog1, catalog2)
+      result = OctocatalogDiff::CatalogDiff::Display.output(diff, display_opts, logger)
+      answer = [
+        '  File[/tmp/foo] =>',
+        '   parameters =>',
+        '     content =>',
+        '      - file line____',
+        '      + file line___',
+        '*******************************************'
+      ]
+      expect(result).to eq(answer)
+    end
+  end
+
+  context 'whitespace manipulation with colors enabled' do
+    let(:display_opts) { { format: :color_text } }
+
+    it 'should properly add space between +/- and single string diff' do
+      catalog1 = build_catalog(base_catalog, 'old value')
+      catalog2 = build_catalog(base_catalog, 'new value')
+      diff = OctocatalogDiff::CatalogDiff::Differ.new(diff_opts, catalog1, catalog2)
+      result = OctocatalogDiff::CatalogDiff::Display.output(diff, display_opts, logger)
+      answer = [
+        '  File[/tmp/foo] =>',
+        '   parameters =>',
+        '     content =>',
+        "      \e[31m- old value\e[0m",
+        "      \e[32m+ new value\e[0m",
+        '*******************************************'
+      ]
+      expect(result).to eq(answer)
+    end
+
+    it 'should properly colorize newline warning in old diff' do
+      catalog1 = build_catalog(base_catalog, 'file line')
+      catalog2 = build_catalog(base_catalog, "file line\n")
+      diff = OctocatalogDiff::CatalogDiff::Differ.new(diff_opts, catalog1, catalog2)
+      result = OctocatalogDiff::CatalogDiff::Display.output(diff, display_opts, logger)
+      answer = [
+        '  File[/tmp/foo] =>',
+        '   parameters =>',
+        '     content =>',
+        "      \e[31m- file line\e[0m",
+        '      \\ No newline at end of file',
+        "      \e[32m+ file line\e[0m",
+        '*******************************************'
+      ]
+      expect(result).to eq(answer)
+    end
+
+    it 'should properly colorize newline warning in new diff' do
+      catalog1 = build_catalog(base_catalog, "file line\n")
+      catalog2 = build_catalog(base_catalog, 'file line')
+      diff = OctocatalogDiff::CatalogDiff::Differ.new(diff_opts, catalog1, catalog2)
+      result = OctocatalogDiff::CatalogDiff::Display.output(diff, display_opts, logger)
+      answer = [
+        '  File[/tmp/foo] =>',
+        '   parameters =>',
+        '     content =>',
+        "      \e[31m- file line\e[0m",
+        "      \e[32m+ file line\e[0m",
+        '      \\ No newline at end of file',
+        '*******************************************'
+      ]
+      expect(result).to eq(answer)
+    end
+  end
+end

--- a/spec/octocatalog-diff/tests/catalog-diff/display/text_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-diff/display/text_spec.rb
@@ -337,8 +337,8 @@ describe OctocatalogDiff::CatalogDiff::Display::Text do
             '  Foo[Bar] =>',
             '   baz =>',
             '     buzz =>',
-            "\e[0;31;49m      - old string\e[0m",
-            "\e[0;32;49m      + new string\e[0m",
+            "      \e[31m- old string\e[0m",
+            "      \e[32m+ new string\e[0m",
             @separator
           ]
           result = OctocatalogDiff::CatalogDiff::Display::Text.generate(diff, color: true, header: 'header')
@@ -404,6 +404,7 @@ describe OctocatalogDiff::CatalogDiff::Display::Text do
             '     buzz =>',
             "      \e[36m@@ -1 +1,2 @@\e[0m",
             "      \e[31m-old string\e[0m",
+            '      \\ No newline at end of file',
             "      \e[32m+new string\e[0m",
             "      \e[32m+new string 2\e[0m",
             @separator

--- a/spec/octocatalog-diff/tests/catalog-diff/display/text_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-diff/display/text_spec.rb
@@ -1019,4 +1019,67 @@ describe OctocatalogDiff::CatalogDiff::Display::Text do
       expect(logger_str.string).to eq('')
     end
   end
+
+  describe '#adjust_position_of_plus_minus' do
+    it 'should work with colorized string' do
+      input = "\e[31m-file line\e[0m"
+      result = described_class.adjust_position_of_plus_minus(input)
+      expect(result).to eq("\e[31m- file line\e[0m")
+    end
+
+    it 'should work with non-colorized string' do
+      input = '-file line'
+      result = described_class.adjust_position_of_plus_minus(input)
+      expect(result).to eq('- file line')
+    end
+  end
+
+  describe '#make_trailing_whitespace_visible' do
+    it 'should work with colorized string' do
+      input = "\e[31m- file line    \e[0m"
+      result = described_class.make_trailing_whitespace_visible(input)
+      expect(result).to eq("\e[31m- file line____\e[0m")
+    end
+
+    it 'should work with non-colorized string' do
+      input = '- file line    '
+      result = described_class.make_trailing_whitespace_visible(input)
+      expect(result).to eq('- file line____')
+    end
+
+    it 'should work with colorized string with no trailing whitespace' do
+      input = "\e[31m- file line\e[0m"
+      result = described_class.make_trailing_whitespace_visible(input)
+      expect(result).to eq("\e[31m- file line\e[0m")
+    end
+
+    it 'should work with a non-colorized string with no trailing whitespace' do
+      input = '- file line'
+      result = described_class.make_trailing_whitespace_visible(input)
+      expect(result).to eq('- file line')
+    end
+
+    it 'should convert special spaces to character equivalents' do
+      input = "test \r\n\t\f"
+      result = described_class.make_trailing_whitespace_visible(input)
+      expect(result).to eq('test_\\r\\n\\t\\f')
+    end
+  end
+
+  describe '#add_trailing_newlines' do
+    it 'should add newlines when neither string ends in newline' do
+      result = described_class.add_trailing_newlines('one', 'two')
+      expect(result).to eq(%W(one\n two\n))
+    end
+
+    it 'should not add newlines when one string ends in newline and the other does not' do
+      result = described_class.add_trailing_newlines('one', "two\n")
+      expect(result).to eq(%W(one two\n))
+    end
+
+    it 'should not add newlines when both strings end in newline' do
+      result = described_class.add_trailing_newlines("one\n", "two\n")
+      expect(result).to eq(%W(one\n two\n))
+    end
+  end
 end


### PR DESCRIPTION
This pull request adds better displays of whitespace-only diffs in strings.

Old:

```
*******************************************
  Authorized_key[some-user] =>
   parameters =>
     key =>
```

New:

```
*******************************************
  Authorized_key[some-user] =>
   parameters =>
     key =>
      - asldfjlsdfkjaflkajsfadlsfkja
      \ No newline at end of file
      + asldfjlsdfkjaflkajsfadlsfkja
```