### PR TITLE
[minor] [doc] fix link to advanced-environments.md

### DIFF
--- a/doc/advanced.md
+++ b/doc/advanced.md
@@ -23,7 +23,7 @@ See also:
 - [Puppet Enterprise node classification service](/doc/advanced-pe-enc.md)
 - [Using `octocatalog-diff` without git](/doc/advanced-using-without-git.md)
 - [Catalog validation](/doc/advanced-catalog-validation.md)
-- [Environment setup](/doc/advanced-environment.md)
+- [Environment setup](/doc/advanced-environments.md)
 
 ### Controlling output
 


### PR DESCRIPTION
This PR just fixes the minor documentation link typo on advanced.md