### PR TITLE
Command line option for Puppet Master timeout

### DIFF
--- a/doc/optionsref.md
+++ b/doc/optionsref.md
@@ -124,6 +124,12 @@ Usage: octocatalog-diff [command line options]
                                      Override parameter from ENC for the to branch
         --from-enc-override STRING1[,STRING2[,...]]
                                      Override parameter from ENC for the from branch
+        --puppet-master-timeout STRING
+                                     Puppet Master catalog retrieval timeout in seconds globally
+        --to-puppet-master-timeout STRING
+                                     Puppet Master catalog retrieval timeout in seconds for the to branch
+        --from-puppet-master-timeout STRING
+                                     Puppet Master catalog retrieval timeout in seconds for the from branch
         --pe-enc-url URL             Base URL for Puppet Enterprise ENC endpoint
         --pe-enc-token TOKEN         Token to access the Puppet Enterprise ENC API
         --pe-enc-token-file PATH     Path containing token for PE node classifier, relative or absolute

--- a/lib/octocatalog-diff/catalog/puppetmaster.rb
+++ b/lib/octocatalog-diff/catalog/puppetmaster.rb
@@ -47,7 +47,7 @@ module OctocatalogDiff
         @catalog = nil
         @error_message = nil
         @retries = nil
-        @timeout = options.fetch(:timeout, PUPPET_MASTER_TIMEOUT)
+        @timeout = options.fetch(:puppet_master_timeout, options.fetch(:timeout, PUPPET_MASTER_TIMEOUT))
 
         # Cannot convert file resources from this type of catalog right now.
         # FIXME: This is possible with additional API calls but is current unimplemented.

--- a/lib/octocatalog-diff/cli/options/puppet_master_timeout.rb
+++ b/lib/octocatalog-diff/cli/options/puppet_master_timeout.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Specify a timeout for retrieving a catalog from a Puppet master / Puppet server.
+# This timeout is specified in seconds.
+# @param parser [OptionParser object] The OptionParser argument
+# @param options [Hash] Options hash being constructed; this is modified in this method.
+OctocatalogDiff::Cli::Options::Option.newoption(:puppet_master_timeout) do
+  has_weight 329
+
+  def parse(parser, options)
+    OctocatalogDiff::Cli::Options.option_globally_or_per_branch(
+      parser: parser,
+      options: options,
+      cli_name: 'puppet-master-timeout',
+      option_name: 'puppet_master_timeout',
+      desc: 'Puppet Master catalog retrieval timeout in seconds',
+      validator: ->(x) { x.to_i > 0 || raise(ArgumentError, 'Specify timeout as a integer greater than 0') },
+      translator: ->(x) { x.to_i }
+    )
+  end
+end

--- a/spec/octocatalog-diff/tests/cli/options/puppet_master_timeout_spec.rb
+++ b/spec/octocatalog-diff/tests/cli/options/puppet_master_timeout_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative '../options_helper'
+
+describe OctocatalogDiff::Cli::Options do
+  describe '#opt_puppet_master_timeout' do
+    it 'should handle --puppet-master-timeout with timeout as a string' do
+      result = run_optparse(['--puppet-master-timeout', '20'])
+      expect(result[:to_puppet_master_timeout]).to eq(20)
+      expect(result[:from_puppet_master_timeout]).to eq(20)
+    end
+
+    it 'should raise error if --puppet-master-timeout == 0' do
+      expect do
+        run_optparse(['--puppet-master-timeout', '0'])
+      end.to raise_error(ArgumentError, 'Specify timeout as a integer greater than 0')
+    end
+
+    it 'should raise error if --puppet-master-timeout evaluates to 0' do
+      expect do
+        run_optparse(['--puppet-master-timeout', 'chickens'])
+      end.to raise_error(ArgumentError, 'Specify timeout as a integer greater than 0')
+    end
+
+    it 'should handle --to-puppet-master-timeout' do
+      result = run_optparse(['--to-puppet-master-timeout', '3'])
+      expect(result[:to_puppet_master_timeout]).to eq(3)
+    end
+
+    it 'should handle --from-puppet-master-timeout' do
+      result = run_optparse(['--from-puppet-master-timeout', '3'])
+      expect(result[:from_puppet_master_timeout]).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
Add a command line option to specify the timeout for retrieving a catalog from a Puppet master.

Don't ask me why. 😉 🙄 