### PR TITLE
#85: Feature/use environment without preserve

### DIFF
--- a/lib/octocatalog-diff/catalog-util/builddir.rb
+++ b/lib/octocatalog-diff/catalog-util/builddir.rb
@@ -330,7 +330,7 @@ module OctocatalogDiff
       end
 
       def environment
-        @options[:preserve_environments] ? @options.fetch(:environment, 'production') : 'production'
+        @options.fetch(:environment, 'production')
       end
     end
   end

--- a/lib/octocatalog-diff/catalog-util/builddir.rb
+++ b/lib/octocatalog-diff/catalog-util/builddir.rb
@@ -84,11 +84,14 @@ module OctocatalogDiff
             install_directory_symlink(logger, File.join(@options[:basedir], x), x)
           end
         else
-          if @options[:environment]
-            install_directory_symlink(logger, @options[:basedir], "environments/#{@options[:environment]}")
-          end
-          if @options[:create_symlinks]
+          if @options[:create_symlinks] && @options[:environment]
+            unless logger.nil?
+              logger.warn '--create-symlinks with --environment ignored unless --preserve-environments is used'
+            end
+          elsif @options[:create_symlinks]
             logger.warn '--create-symlinks is ignored unless --preserve-environments is used' unless logger.nil?
+          elsif @options[:environment]
+            install_directory_symlink(logger, @options[:basedir], "environments/#{@options[:environment]}")
           end
           install_directory_symlink(logger, @options[:basedir])
         end
@@ -178,6 +181,7 @@ module OctocatalogDiff
       def install_directory_symlink(logger, dir, target = 'environments/production')
         raise ArgumentError, "Called install_directory_symlink with #{dir.class} argument" unless dir.is_a?(String)
         raise Errno::ENOENT, "Specified directory #{dir} doesn't exist" unless File.directory?(dir)
+
         symlink_target = File.join(@tempdir, target)
 
         if target =~ %r{/}

--- a/lib/octocatalog-diff/catalog-util/builddir.rb
+++ b/lib/octocatalog-diff/catalog-util/builddir.rb
@@ -91,7 +91,7 @@ module OctocatalogDiff
           elsif @options[:create_symlinks]
             logger.warn '--create-symlinks is ignored unless --preserve-environments is used' unless logger.nil?
           elsif @options[:environment]
-            install_directory_symlink(logger, @options[:basedir], "environments/#{@options[:environment]}")
+            return install_directory_symlink(logger, @options[:basedir], "environments/#{@options[:environment]}")
           end
           install_directory_symlink(logger, @options[:basedir])
         end

--- a/lib/octocatalog-diff/catalog-util/builddir.rb
+++ b/lib/octocatalog-diff/catalog-util/builddir.rb
@@ -85,7 +85,7 @@ module OctocatalogDiff
           end
         else
           if @options[:environment]
-            logger.warn '--environment is ignored unless --preserve-environments is used' unless logger.nil?
+            install_directory_symlink(logger, @options[:basedir], "environments/#{@options[:environment]}")
           end
           if @options[:create_symlinks]
             logger.warn '--create-symlinks is ignored unless --preserve-environments is used' unless logger.nil?

--- a/lib/octocatalog-diff/catalog-util/command.rb
+++ b/lib/octocatalog-diff/catalog-util/command.rb
@@ -78,7 +78,7 @@ module OctocatalogDiff
         # Add environment - only make this variable if preserve_environments is used.
         # If preserve_environments is not used, the hard-coded 'production' here matches
         # up with the symlink created under the temporary directory structure.
-        environ = @options[:preserve_environments] ? @options.fetch(:environment, 'production') : 'production'
+        environ = @options.fetch(:environment, 'production')
         cmdline << "--environment=#{Shellwords.escape(environ)}"
 
         # For people who aren't running hiera, a hiera-config will not be generated when @options[:hiera_config]

--- a/lib/octocatalog-diff/catalog/computed.rb
+++ b/lib/octocatalog-diff/catalog/computed.rb
@@ -80,7 +80,7 @@ module OctocatalogDiff
 
       # Environment used to compile catalog
       def environment
-        @opts[:preserve_environments] ? @opts.fetch(:environment, 'production') : 'production'
+        @options.fetch(:environment, 'production')
       end
 
       private

--- a/lib/octocatalog-diff/catalog/computed.rb
+++ b/lib/octocatalog-diff/catalog/computed.rb
@@ -80,7 +80,7 @@ module OctocatalogDiff
 
       # Environment used to compile catalog
       def environment
-        @options.fetch(:environment, 'production')
+        @opts.fetch(:environment, 'production')
       end
 
       private

--- a/spec/octocatalog-diff/integration/preserve_environments_spec.rb
+++ b/spec/octocatalog-diff/integration/preserve_environments_spec.rb
@@ -47,7 +47,7 @@ describe 'preserve environments integration' do
       end
 
       it 'should exit without error' do
-        expect(@result.exitcode).to eq(2), OctocatalogDiff::Integration.format_exception(@result)
+        expect(@result.exitcode).to eq(0), OctocatalogDiff::Integration.format_exception(@result)
         expect(@result.exception).to be_nil, OctocatalogDiff::Integration.format_exception(@result)
       end
     end

--- a/spec/octocatalog-diff/integration/preserve_environments_spec.rb
+++ b/spec/octocatalog-diff/integration/preserve_environments_spec.rb
@@ -40,19 +40,15 @@ describe 'preserve environments integration' do
             '-n', 'rspec-node.github.net',
             '--environment', 'asdfgh',
             '--to-catalog', OctocatalogDiff::Spec.fixture_path('catalogs/default-catalog-v4.json'),
-            '--hiera-config', 'environments/production/config/hiera.yaml',
+            '--hiera-config', 'config/hiera.yaml',
             '--hiera-path-strip', '/var/lib/puppet', '--no-parallel'
           ]
         )
       end
 
       it 'should exit without error' do
-        expect(@result.exitcode).to eq(0), OctocatalogDiff::Integration.format_exception(@result)
+        expect(@result.exitcode).to eq(2), OctocatalogDiff::Integration.format_exception(@result)
         expect(@result.exception).to be_nil, OctocatalogDiff::Integration.format_exception(@result)
-      end
-
-      it 'should log warning about --environment being useless in this context' do
-        expect(@result.logs).to match(/WARN -- : --environment is ignored unless --preserve-environments is used/)
       end
     end
 

--- a/spec/octocatalog-diff/tests/catalog-util/builddir_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-util/builddir_spec.rb
@@ -87,7 +87,7 @@ describe OctocatalogDiff::CatalogUtil::BuildDir do
       context 'with --create-symlinks' do
         context 'with logger' do
           it 'should log a warning message and install default symlink' do
-            logger = double('Logger')
+            logger, = OctocatalogDiff::Spec.setup_logger
             expect(logger).to receive(:warn).with('--create-symlinks is ignored unless --preserve-environments is used')
 
             @described_object.instance_variable_set(
@@ -124,7 +124,7 @@ describe OctocatalogDiff::CatalogUtil::BuildDir do
       context 'with --create-symlinks and --environment' do
         context 'with logger' do
           it 'should log a warning message and install default symlink' do
-            logger = double('Logger')
+            logger, = OctocatalogDiff::Spec.setup_logger
             expect(logger).to receive(:warn).with(
               '--create-symlinks with --environment ignored unless --preserve-environments is used'
             )
@@ -164,7 +164,7 @@ describe OctocatalogDiff::CatalogUtil::BuildDir do
       context 'with --environment' do
         context 'with logger' do
           it 'should install a symlink to the given environment' do
-            logger = double('Logger')
+            logger, = OctocatalogDiff::Spec.setup_logger
 
             @described_object.instance_variable_set(
               '@options',
@@ -199,7 +199,7 @@ describe OctocatalogDiff::CatalogUtil::BuildDir do
 
       context 'without --create-symlinks or --environment' do
         it 'should install directory symlink' do
-          logger = double('Logger')
+          logger, = OctocatalogDiff::Spec.setup_logger
 
           @described_object.instance_variable_set(
             '@options',

--- a/spec/octocatalog-diff/tests/catalog-util/builddir_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-util/builddir_spec.rb
@@ -157,6 +157,41 @@ describe OctocatalogDiff::CatalogUtil::BuildDir do
           end
         end
       end
+      context 'with --environment' do
+        context 'with logger' do
+          it 'should install a symlink to the given environment' do
+            logger = double('Logger')
+
+            @described_object.instance_variable_set(
+              '@options',
+              basedir: '/tmp/basedir',
+              environment: 'baz'
+            )
+
+            expect(@described_object)
+              .to receive(:install_directory_symlink)
+              .with(logger, '/tmp/basedir', 'environments/baz')
+
+            expect { @described_object.send(:create_symlinks, logger) }.not_to raise_error
+          end
+        end
+
+        context 'without logger' do
+          it 'should install default symlink' do
+            @described_object.instance_variable_set(
+              '@options',
+              basedir: '/tmp/basedir',
+              environment: 'baz'
+            )
+
+            expect(@described_object)
+              .to receive(:install_directory_symlink)
+              .with(nil, '/tmp/basedir', 'environments/baz')
+
+            expect { @described_object.send(:create_symlinks) }.not_to raise_error
+          end
+        end
+      end
 
       context 'without --create-symlinks or --environment' do
         it 'should install directory symlink' do

--- a/spec/octocatalog-diff/tests/catalog-util/builddir_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-util/builddir_spec.rb
@@ -121,15 +121,18 @@ describe OctocatalogDiff::CatalogUtil::BuildDir do
         end
       end
 
-      context 'with --environment' do
+      context 'with --create-symlinks and --environment' do
         context 'with logger' do
           it 'should log a warning message and install default symlink' do
             logger = double('Logger')
-            expect(logger).to receive(:warn).with('--environment is ignored unless --preserve-environments is used')
+            expect(logger).to receive(:warn).with(
+              '--create-symlinks with --environment ignored unless --preserve-environments is used'
+            )
 
             @described_object.instance_variable_set(
               '@options',
               basedir: '/tmp/basedir',
+              create_symlinks: %w(foo bar),
               environment: 'baz'
             )
 
@@ -142,10 +145,11 @@ describe OctocatalogDiff::CatalogUtil::BuildDir do
         end
 
         context 'without logger' do
-          it 'should install default symlink' do
+          it 'should install directory symlink' do
             @described_object.instance_variable_set(
               '@options',
               basedir: '/tmp/basedir',
+              create_symlinks: %w(foo bar),
               environment: 'baz'
             )
 

--- a/spec/octocatalog-diff/tests/catalog-util/builddir_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-util/builddir_spec.rb
@@ -145,7 +145,7 @@ describe OctocatalogDiff::CatalogUtil::BuildDir do
         end
 
         context 'without logger' do
-          it 'should install directory symlink' do
+          it 'should install default symlink' do
             @described_object.instance_variable_set(
               '@options',
               basedir: '/tmp/basedir',

--- a/spec/octocatalog-diff/tests/catalog/computed_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog/computed_spec.rb
@@ -422,17 +422,19 @@ describe OctocatalogDiff::Catalog::Computed do
     context 'when preserve_environments is not set' do
       context 'and environment is specified' do
         it 'should return without raising error when directory exists' do
-          allow(File).to receive(:"directory?").with('/tmp/assert/environments/production').and_return(true)
+          allow(File).to receive(:"directory?").with('/tmp/assert/environments/production').and_return(false)
+          allow(File).to receive(:"directory?").with('/tmp/assert/environments/custom').and_return(true)
           described_object = described_class.allocate
-          described_object.instance_variable_set('@opts', environment: 'nope')
+          described_object.instance_variable_set('@opts', environment: 'custom')
           described_object.instance_variable_set('@builddir', OpenStruct.new(tempdir: '/tmp/assert'))
           expect { described_object.send(:assert_that_puppet_environment_directory_exists) }.not_to raise_error
         end
 
         it 'should raise Errno::ENOENT when directory does not exist' do
-          allow(File).to receive(:"directory?").with('/tmp/assert/environments/production').and_return(false)
+          allow(File).to receive(:"directory?").with('/tmp/assert/environments/production').and_return(true)
+          allow(File).to receive(:"directory?").with('/tmp/assert/environments/custom').and_return(false)
           described_object = described_class.allocate
-          described_object.instance_variable_set('@opts', environment: 'yup')
+          described_object.instance_variable_set('@opts', environment: 'custom')
           described_object.instance_variable_set('@builddir', OpenStruct.new(tempdir: '/tmp/assert'))
           expect { described_object.send(:assert_that_puppet_environment_directory_exists) }.to raise_error(Errno::ENOENT)
         end


### PR DESCRIPTION
## Overview

This pull request changes the behaviour of the `--environment` flag when used on its own.

Solve the problem described in #85. Allows the `--environment` flag to be used without the `--preserve-environments` flag. 

Tries to maintain the current functionality by ignoring this parameter when used with `--create-symlinks`. 

Doesn't modify the existing behaviour of `--preserve-environments`

## Checklist

- [x] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [ ] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [x] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended.
- [x] If you have added any new gem dependencies, make sure those gems are licensed under the MIT or Apache 2.0 license. We cannot add any dependencies on gems licensed under GPL.
- [x] If you have added any new gem dependencies, make sure you've checked in a copy of the `.gem` file into the [vendor/cache](https://github.com/github/octocatalog-diff/tree/master/vendor/cache) directory.