### PR TITLE
Fixed #93 Make puppet version check respect env vars

### DIFF
--- a/lib/octocatalog-diff/catalog/computed.rb
+++ b/lib/octocatalog-diff/catalog/computed.rb
@@ -68,7 +68,7 @@ module OctocatalogDiff
       # @return [String] Puppet version
       def puppet_version
         raise ArgumentError, '"puppet_binary" was not passed to OctocatalogDiff::Catalog::Computed' unless @puppet_binary
-        @puppet_version ||= OctocatalogDiff::Util::PuppetVersion.puppet_version(@puppet_binary)
+        @puppet_version ||= OctocatalogDiff::Util::PuppetVersion.puppet_version(@puppet_binary, @opts)
       end
 
       # Compilation directory

--- a/lib/octocatalog-diff/util/puppetversion.rb
+++ b/lib/octocatalog-diff/util/puppetversion.rb
@@ -12,8 +12,9 @@ module OctocatalogDiff
     class PuppetVersion
       # Determine the version of Puppet.
       # @param puppet [String] Path to Puppet binary
+      # @param options [Hash] Options hash as defined in OctocatalogDiff::Catalog::Computed
       # @return [String] Puppet version number
-      def self.puppet_version(puppet)
+      def self.puppet_version(puppet, options = {})
         raise ArgumentError, 'Puppet binary was not supplied' if puppet.nil?
         raise Errno::ENOENT, "Puppet binary #{puppet} doesn't exist" unless File.file?(puppet)
         cmdline = [Shellwords.escape(puppet), '--version'].join(' ')
@@ -24,6 +25,8 @@ module OctocatalogDiff
           'PATH' => ENV['PATH'],
           'PWD' => File.dirname(puppet)
         }
+        pass_env_vars = options.fetch(:pass_env_vars, [])
+        pass_env_vars.each { |var| env[var] ||= ENV[var] }
         out, err, _status = Open3.capture3(env, cmdline, unsetenv_others: true, chdir: env['PWD'])
         return Regexp.last_match(1) if out =~ /^([\d\.]+)\s*$/
         raise "Unable to determine Puppet version: #{out} #{err}"


### PR DESCRIPTION
## Overview

This pull request fixes #93 

It adds an optional param to the version check method which, if supplied will allow the command to retain extra environment variables as expected

## Checklist

- [x] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [x] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [x] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended.
- [x] If you have added any new gem dependencies, make sure those gems are licensed under the MIT or Apache 2.0 license. We cannot add any dependencies on gems licensed under GPL.
- [x] If you have added any new gem dependencies, make sure you've checked in a copy of the `.gem` file into the [vendor/cache](https://github.com/github/octocatalog-diff/tree/master/vendor/cache) directory.

/cc #93 @kpaulisse 
