### PR TITLE
Support hiera.yaml backend declared as a string instead of array

### DIFF
--- a/lib/octocatalog-diff/catalog-util/builddir.rb
+++ b/lib/octocatalog-diff/catalog-util/builddir.rb
@@ -234,7 +234,7 @@ module OctocatalogDiff
 
         # Munge datadir in hiera config file
         obj = YAML.load_file(file_src)
-        (obj[:backends] || %w(yaml json)).each do |key|
+        ([obj[:backends]].flatten || %w(yaml json)).each do |key|
           next unless obj.key?(key.to_sym)
           if options[:hiera_path_strip].is_a?(String)
             next if obj[key.to_sym][:datadir].nil?

--- a/spec/octocatalog-diff/fixtures/repos/default/config/hiera-backend-as-string.yaml
+++ b/spec/octocatalog-diff/fixtures/repos/default/config/hiera-backend-as-string.yaml
@@ -1,0 +1,13 @@
+---
+:backends: yaml
+:yaml:
+  :datadir: /var/lib/puppet/environments/%{::environment}/hieradata
+:hierarchy:
+  - servers/%{::fqdn}
+  - datacenter/%{::datacenter}
+  - platform/%{::virtual}
+  - os/%{::operatingsystem}/%{::lsbdistcodename}
+  - os/%{::operatingsystem}
+  - common
+:merge_behavior: deeper
+:logger: console

--- a/spec/octocatalog-diff/tests/catalog-util/builddir_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-util/builddir_spec.rb
@@ -514,6 +514,24 @@ describe OctocatalogDiff::CatalogUtil::BuildDir do
         expect(logger_str.string).not_to match(/Hiera datadir for json doesn't seem to exist/)
       end
     end
+
+    # https://github.com/github/octocatalog-diff/issues/107
+    # https://docs.puppet.com/hiera/3.3/configuring.html#backends
+    context 'with backend as a string' do
+      it 'should handle backend declared as a single string' do
+        options = default_options.merge(
+          hiera_config: OctocatalogDiff::Spec.fixture_path('repos/default/config/hiera-backend-as-string.yaml'),
+          hiera_path: 'hieradata'
+        )
+        logger, _logger_str = OctocatalogDiff::Spec.setup_logger
+        testobj = OctocatalogDiff::CatalogUtil::BuildDir.new(options, logger)
+        hiera_yaml = File.join(testobj.tempdir, 'hiera.yaml')
+        expect(File.file?(hiera_yaml)).to eq(true)
+        hiera_cfg = YAML.load_file(hiera_yaml)
+        expect(hiera_cfg[:backends]).to eq('yaml')
+        expect(hiera_cfg[:yaml]).to eq(datadir: File.join(testobj.tempdir, 'environments', 'production', 'hieradata'))
+      end
+    end
   end
 
   describe '#install_fact_file' do


### PR DESCRIPTION
Fixes https://github.com/github/octocatalog-diff/issues/107

This allows the hiera.yaml file to declare a single backend as a string rather than an array, since Puppet allows that.