### PR TITLE
Ruby 2.4 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ script: "script/cibuild"
 matrix:
   include:
     # Build with latest ruby
-    - rvm: 2.4
+    - rvm: 2.4.1
       env: RUBOCOP_TEST="true" RSPEC_TEST="true"
     # Build with older ruby versions
-    - rvm: 2.3
+    - rvm: 2.3.4
       env: RUBOCOP_TEST="false" RSPEC_TEST="true"
     - rvm: 2.2
       env: RUBOCOP_TEST="false" RSPEC_TEST="true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,11 @@ script: "script/cibuild"
 matrix:
   include:
     # Build with latest ruby
-    - rvm: 2.3.1
+    - rvm: 2.4
       env: RUBOCOP_TEST="true" RSPEC_TEST="true"
     # Build with older ruby versions
+    - rvm: 2.3
+      env: RUBOCOP_TEST="false" RSPEC_TEST="true"
     - rvm: 2.2
       env: RUBOCOP_TEST="false" RSPEC_TEST="true"
     - rvm: 2.1

--- a/doc/dev/integration-tests.md
+++ b/doc/dev/integration-tests.md
@@ -22,7 +22,7 @@ describe 'whatever behavior' do
     # @result[:logs] is a String containing everything printed to STDERR (Logger)
     # @result[:output] is a String containing everything printed to STDOUT
     # @result[:diffs] is an Array of differences
-    # @result[:exitcode] is a Integer representing the exit code: 0 = no changes, 1 = failure, 2 = success, with changes
+    # @result[:exitcode] is an Integer representing the exit code: 0 = no changes, 1 = failure, 2 = success, with changes
     # @result[:exception] contains any exception that was thrown
   end
 
@@ -46,7 +46,7 @@ describe 'whatever behavior' do
     # @result[:logs] is a String containing everything printed to STDERR (Logger)
     # @result[:output] is a String containing everything printed to STDOUT
     # @result[:diffs] is an Array of differences
-    # @result[:exitcode] is a Integer representing the exit code: 0 = no changes, 1 = failure, 2 = success, with changes
+    # @result[:exitcode] is an Integer representing the exit code: 0 = no changes, 1 = failure, 2 = success, with changes
     # @result[:exception] contains any exception that was thrown
   end
 

--- a/doc/dev/integration-tests.md
+++ b/doc/dev/integration-tests.md
@@ -22,7 +22,7 @@ describe 'whatever behavior' do
     # @result[:logs] is a String containing everything printed to STDERR (Logger)
     # @result[:output] is a String containing everything printed to STDOUT
     # @result[:diffs] is an Array of differences
-    # @result[:exitcode] is a Fixnum representing the exit code: 0 = no changes, 1 = failure, 2 = success, with changes
+    # @result[:exitcode] is a Integer representing the exit code: 0 = no changes, 1 = failure, 2 = success, with changes
     # @result[:exception] contains any exception that was thrown
   end
 
@@ -46,7 +46,7 @@ describe 'whatever behavior' do
     # @result[:logs] is a String containing everything printed to STDERR (Logger)
     # @result[:output] is a String containing everything printed to STDOUT
     # @result[:diffs] is an Array of differences
-    # @result[:exitcode] is a Fixnum representing the exit code: 0 = no changes, 1 = failure, 2 = success, with changes
+    # @result[:exitcode] is a Integer representing the exit code: 0 = no changes, 1 = failure, 2 = success, with changes
     # @result[:exception] contains any exception that was thrown
   end
 

--- a/doc/requirements.md
+++ b/doc/requirements.md
@@ -2,10 +2,10 @@
 
 To run `octocatalog-diff` you will need these basics:
 
-- Ruby 2.0 or higher
+- Ruby 2.0 or higher (we test octocatalog-diff with Ruby 2.0, 2.1, 2.2, 2.3, and 2.4)
 - Mac OS, Linux, or other Unix-line operating system (Windows is not supported)
 - Ability to install gems, e.g. with [rbenv](https://github.com/rbenv/rbenv) or [rvm](https://rvm.io/), or root privileges to install into the system Ruby
-- Puppet agent for [Linux](https://docs.puppet.com/puppet/latest/reference/install_linux.html) or [Mac OS X](https://docs.puppet.com/puppet/latest/reference/install_osx.html), or installed as a gem
+- Puppet agent for [Linux](https://docs.puppet.com/puppet/latest/reference/install_linux.html) or [Mac OS X](https://docs.puppet.com/puppet/latest/reference/install_osx.html), or installed as a gem (we support Puppet 3.8.7 and all versions of Puppet 4.x)
 
 We recommend that you also have the following to get the most out of `octocatalog-diff`, but these are not absolute requirements:
 

--- a/doc/requirements.md
+++ b/doc/requirements.md
@@ -2,7 +2,7 @@
 
 To run `octocatalog-diff` you will need these basics:
 
-- Ruby 2.0 or higher (we test octocatalog-diff with Ruby 2.0, 2.1, 2.2, 2.3, and 2.4)
+- Ruby 2.0 through 2.4 (we test octocatalog-diff with Ruby 2.0, 2.1, 2.2, 2.3, and 2.4)
 - Mac OS, Linux, or other Unix-line operating system (Windows is not supported)
 - Ability to install gems, e.g. with [rbenv](https://github.com/rbenv/rbenv) or [rvm](https://rvm.io/), or root privileges to install into the system Ruby
 - Puppet agent for [Linux](https://docs.puppet.com/puppet/latest/reference/install_linux.html) or [Mac OS X](https://docs.puppet.com/puppet/latest/reference/install_osx.html), or installed as a gem (we support Puppet 3.8.7 and all versions of Puppet 4.x)

--- a/lib/octocatalog-diff/api/v1/override.rb
+++ b/lib/octocatalog-diff/api/v1/override.rb
@@ -72,9 +72,9 @@ module OctocatalogDiff
           return value if datatype == 'string'
           return parse_json(value) if datatype == 'json'
           return nil if datatype == 'nil'
-          if datatype == 'fixnum'
+          if datatype == 'fixnum' || datatype == 'integer'
             return Regexp.last_match(1).to_i if value =~ /^(-?\d+)$/
-            raise ArgumentError, "Illegal fixnum '#{value}'"
+            raise ArgumentError, "Illegal integer '#{value}'"
           end
           if datatype == 'float'
             return Regexp.last_match(1).to_f if value =~ /^(-?\d*\.\d+)$/

--- a/lib/octocatalog-diff/bootstrap.rb
+++ b/lib/octocatalog-diff/bootstrap.rb
@@ -10,7 +10,7 @@ module OctocatalogDiff
     # @param options [Hash] Options hash:
     #        :path [String] => Directory to bootstrap
     #        :bootstrap_script [String] => Bootstrap script, relative to directory
-    # @return [Hash] => [Fixnum] :status_code, [String] :output
+    # @return [Hash] => [Integer] :status_code, [String] :output
     def self.bootstrap(options = {})
       # Options validation
       unless options[:path].is_a?(String)

--- a/lib/octocatalog-diff/catalog-diff/differ.rb
+++ b/lib/octocatalog-diff/catalog-diff/differ.rb
@@ -533,7 +533,7 @@ module OctocatalogDiff
 
           # Added a new key that points to some kind of data structure that we know how
           # to handle.
-          if obj[1] =~ /^(.+)\f([^\f]+)$/ && [String, Fixnum, Float, TrueClass, FalseClass, Array, Hash].include?(obj[2].class)
+          if obj[1] =~ /^(.+)\f([^\f]+)$/ && [String, Integer, Float, TrueClass, FalseClass, Array, Hash].include?(obj[2].class)
             hashdiff_add_remove.add(obj[1])
             next
           end

--- a/lib/octocatalog-diff/catalog-diff/display/text.rb
+++ b/lib/octocatalog-diff/catalog-diff/display/text.rb
@@ -439,6 +439,16 @@ module OctocatalogDiff
         end
 
         # Utility Method!
+        # Given a class, output that same class, except preserve some backward compatible
+        # or equivalent class names.
+        # @param class_name [String] Class name as input
+        # @return [String] Class name as output
+        def self.class_name_for_diffy(class_name)
+          return 'Fixnum' if class_name == 'Integer'
+          class_name
+        end
+
+        # Utility Method!
         # Given an arbitrary object, convert it into a string for use by 'diffy'.
         # This basically exists so we can do something prettier than just calling .inspect or .to_s
         # on object types we anticipate seeing, while not failing entirely on other object types.
@@ -448,7 +458,7 @@ module OctocatalogDiff
           return JSON.pretty_generate(obj) if [Hash, Array].include?(obj.class)
           return '""' if obj.is_a?(String) && obj == ''
           return obj if [String, Fixnum, Integer, Float].include?(obj.class)
-          "#{obj.class}: #{obj.inspect}"
+          "#{class_name_for_diffy(obj.class)}: #{obj.inspect}"
         end
 
         # Utility Method!

--- a/lib/octocatalog-diff/catalog-diff/display/text.rb
+++ b/lib/octocatalog-diff/catalog-diff/display/text.rb
@@ -439,13 +439,22 @@ module OctocatalogDiff
         end
 
         # Utility Method!
-        # Given a class, output that same class, except preserve some backward compatible
-        # or equivalent class names.
+        # Harmonize equivalent class names for comparison purposes.
         # @param class_name [String] Class name as input
         # @return [String] Class name as output
         def self.class_name_for_diffy(class_name)
-          return 'Fixnum' if class_name == 'Integer'
+          return 'Integer' if class_name == 'Fixnum'
           class_name
+        end
+
+        # Utility Method!
+        # `is_a?(class)` only allows one method, but this uses an array
+        # @param object [?] Object to consider
+        # @param classes [Array] Classes to determine if object is a member of
+        # @return [Boolean] True if object is_a any of the classes, false otherwise
+        def self.object_is_any_of?(object, classes)
+          classes.each { |clazz| return true if object.is_a? clazz }
+          false
         end
 
         # Utility Method!
@@ -455,9 +464,9 @@ module OctocatalogDiff
         # @param obj [?] Object to be stringified
         # @return [String] String representation of object for diffy
         def self.stringify_for_diffy(obj)
-          return JSON.pretty_generate(obj) if [Hash, Array].include?(obj.class)
+          return JSON.pretty_generate(obj) if object_is_any_of?(obj, [Hash, Array])
           return '""' if obj.is_a?(String) && obj == ''
-          return obj if [String, Fixnum, Integer, Float].include?(obj.class)
+          return obj if object_is_any_of?(obj, [String, Fixnum, Integer, Float])
           "#{class_name_for_diffy(obj.class)}: #{obj.inspect}"
         end
 

--- a/lib/octocatalog-diff/catalog-diff/display/text.rb
+++ b/lib/octocatalog-diff/catalog-diff/display/text.rb
@@ -447,7 +447,7 @@ module OctocatalogDiff
         def self.stringify_for_diffy(obj)
           return JSON.pretty_generate(obj) if [Hash, Array].include?(obj.class)
           return '""' if obj.is_a?(String) && obj == ''
-          return obj if [String, Integer, Float].include?(obj.class)
+          return obj if [String, Fixnum, Integer, Float].include?(obj.class)
           "#{obj.class}: #{obj.inspect}"
         end
 

--- a/lib/octocatalog-diff/catalog-diff/display/text.rb
+++ b/lib/octocatalog-diff/catalog-diff/display/text.rb
@@ -255,7 +255,7 @@ module OctocatalogDiff
         # Get the diff of two long strings. Call the 'diffy' gem for this.
         # @param string1 [String] First string (-)
         # @param string2 [String] Second string (+)
-        # @param depth [Fixnum] Depth, for correct indentation
+        # @param depth [Integer] Depth, for correct indentation
         # @return Array<String> Displayable result
         def self.diff_two_strings_with_diffy(string1, string2, depth)
           # Single line strings?
@@ -324,8 +324,8 @@ module OctocatalogDiff
         # Get the diff of two hashes. Call the 'diffy' gem for this.
         # @param hash1 [Hash] First hash (-)
         # @param hash1 [Hash] Second hash (+)
-        # @param depth [Fixnum] Depth, for correct indentation
-        # @param limit [Fixnum] Maximum string length
+        # @param depth [Integer] Depth, for correct indentation
+        # @param limit [Integer] Maximum string length
         # @param strip_diff [Boolean] Strip leading +/-/" "
         # @return [Array<String>] Displayable result
         def self.diff_two_hashes_with_diffy(opts = {})
@@ -358,7 +358,7 @@ module OctocatalogDiff
         end
 
         # Special case: addition only, no truncation
-        # @param depth [Fixnum] Depth, for correct indentation
+        # @param depth [Integer] Depth, for correct indentation
         # @param hash [Hash] Added object
         # @return [Array<String>] Displayable result
         def self.addition_only_no_truncation(depth, hash)
@@ -383,7 +383,7 @@ module OctocatalogDiff
 
         # Limit length of a string
         # @param str [String] String
-        # @param limit [Fixnum] Limit (0=unlimited)
+        # @param limit [Integer] Limit (0=unlimited)
         # @return [String] Truncated string
         def self.truncate_string(str, limit)
           return str if limit.nil? || str.length <= limit
@@ -392,7 +392,7 @@ module OctocatalogDiff
 
         # Get the diff between two hashes. This is recursive-aware.
         # @param obj [diff object] diff object
-        # @param depth [Fixnum] Depth of nesting, used for indentation
+        # @param depth [Integer] Depth of nesting, used for indentation
         # @return Array<String> Printable diff outputs
         def self.hash_diff(obj, depth, key_in, nested = false)
           result = []
@@ -417,7 +417,7 @@ module OctocatalogDiff
         end
 
         # Get the diff between two arbitrary objects
-        # @param depth [Fixnum] Depth of nesting, used for indentation
+        # @param depth [Integer] Depth of nesting, used for indentation
         # @param old_obj [?] Old object
         # @param new_obj [?] New object
         # @return Array<String> Diff output
@@ -432,7 +432,7 @@ module OctocatalogDiff
 
         # Utility Method!
         # Indent a given text string with a certain number of spaces
-        # @param spaces [Fixnum] Number of spaces
+        # @param spaces [Integer] Number of spaces
         # @param text [String] Text
         def self.left_pad(spaces, text = '')
           [' ' * spaces, text].join('')
@@ -447,7 +447,7 @@ module OctocatalogDiff
         def self.stringify_for_diffy(obj)
           return JSON.pretty_generate(obj) if [Hash, Array].include?(obj.class)
           return '""' if obj.is_a?(String) && obj == ''
-          return obj if [String, Fixnum, Float].include?(obj.class)
+          return obj if [String, Integer, Float].include?(obj.class)
           "#{obj.class}: #{obj.inspect}"
         end
 
@@ -512,8 +512,8 @@ module OctocatalogDiff
           return ['""', 'undef'] if obj2.nil?
 
           # If one is an integer and the other is a string
-          return [obj1, "\"#{obj2}\""] if obj1.is_a?(Fixnum) && obj2.is_a?(String)
-          return ["\"#{obj1}\"", obj2] if obj1.is_a?(String) && obj2.is_a?(Fixnum)
+          return [obj1, "\"#{obj2}\""] if obj1.is_a?(Integer) && obj2.is_a?(String)
+          return ["\"#{obj1}\"", obj2] if obj1.is_a?(String) && obj2.is_a?(Integer)
 
           # True and false
           return [obj1, "\"#{obj2}\""] if obj1.is_a?(TrueClass) && obj2.is_a?(String)

--- a/lib/octocatalog-diff/catalog-util/builddir.rb
+++ b/lib/octocatalog-diff/catalog-util/builddir.rb
@@ -21,7 +21,7 @@ module OctocatalogDiff
       # Constructor
       # Options for constructor:
       # :puppetdb_url [String] PuppetDB Server URLs
-      # :puppetdb_server_url_timeout [Fixnum] Timeout (seconds) for puppetdb.conf
+      # :puppetdb_server_url_timeout [Integer] Timeout (seconds) for puppetdb.conf
       # :facts [OctocatalogDiff::Facts] Facts object
       # :fact_file [String] File from which to read facts
       # :node [String] Node name
@@ -99,14 +99,14 @@ module OctocatalogDiff
 
       # Install puppetdb.conf file in temporary directory
       # @param server_urls [String] String for server_urls in puppetdb.conf
-      # @param server_url_timeout [Fixnum] Value for server_url_timeout in puppetdb.conf
+      # @param server_url_timeout [Integer] Value for server_url_timeout in puppetdb.conf
       def install_puppetdb_conf(logger, server_urls, server_url_timeout = 30)
         unless server_urls.is_a?(String)
           raise ArgumentError, "server_urls must be a string, got a: #{server_urls.class}"
         end
 
         server_url_timeout ||= 30 # If called with nil argument, supply default
-        unless server_url_timeout.is_a?(Fixnum)
+        unless server_url_timeout.is_a?(Integer)
           raise ArgumentError, "server_url_timeout must be a fixnum, got a: #{server_url_timeout.class}"
         end
 

--- a/lib/octocatalog-diff/catalog-util/command.rb
+++ b/lib/octocatalog-diff/catalog-util/command.rb
@@ -167,7 +167,7 @@ module OctocatalogDiff
       # the index.
       # @param cmdline [Array] Existing command line
       # @param key [String] Key to look up
-      # @return [Fixnum] Index of where key is defined (nil if undefined)
+      # @return [Integer] Index of where key is defined (nil if undefined)
       def key_position(cmdline, key)
         cmdline.index { |x| x == "--#{key}" || x =~ /\A--#{key}=/ }
       end

--- a/lib/octocatalog-diff/catalog/computed.rb
+++ b/lib/octocatalog-diff/catalog/computed.rb
@@ -22,7 +22,7 @@ module OctocatalogDiff
       # @param :node [String] REQUIRED: Node name
       # @param :basedir [String] Directory in which to compile the catalog
       # @param :pass_env_vars [Array<String>] Environment variables to pass when compiling catalog
-      # @param :retry_failed_catalog [Fixnum] Number of retries if a catalog compilation fails
+      # @param :retry_failed_catalog [Integer] Number of retries if a catalog compilation fails
       # @param :tag [String] For display purposes, the catalog being compiled
       # @param :puppet_binary [String] Full path to Puppet
       # @param :puppet_version [String] Puppet version (optional; if not supplied, it is calculated)

--- a/lib/octocatalog-diff/catalog/puppetdb.rb
+++ b/lib/octocatalog-diff/catalog/puppetdb.rb
@@ -15,7 +15,7 @@ module OctocatalogDiff
 
       # Constructor - See OctocatalogDiff::PuppetDB for additional parameters
       # @param :node [String] Node name
-      # @param :retry [Fixnum] Number of retries, if fetch fails
+      # @param :retry [Integer] Number of retries, if fetch fails
       def initialize(options)
         raise ArgumentError, 'Hash of options must be passed to OctocatalogDiff::Catalog::PuppetDB' unless options.is_a?(Hash)
         raise ArgumentError, 'node must be a non-empty string' unless options[:node].is_a?(String) && options[:node] != ''

--- a/lib/octocatalog-diff/catalog/puppetmaster.rb
+++ b/lib/octocatalog-diff/catalog/puppetmaster.rb
@@ -22,17 +22,17 @@ module OctocatalogDiff
 
       # Constructor
       # @param :node [String] Node name
-      # @param :retry_failed_catalog [Fixnum] Number of retries, if fetch fails
+      # @param :retry_failed_catalog [Integer] Number of retries, if fetch fails
       # @param :branch [String] Environment to fetch from Puppet Master
       # @param :puppet_master [String] Puppet server and port number (assumed to be DEFAULT_PUPPET_PORT_NUMBER if not given)
-      # @param :puppet_master_api_version [Fixnum] Puppet server API (default DEFAULT_PUPPET_SERVER_API)
+      # @param :puppet_master_api_version [Integer] Puppet server API (default DEFAULT_PUPPET_SERVER_API)
       # @param :puppet_master_ssl_ca [String] Path to file used to sign puppet master's certificate
       # @param :puppet_master_ssl_verify [Boolean] Override the CA verification setting guessed from parameters
       # @param :puppet_master_ssl_client_pem [String] PEM-encoded client key and certificate
       # @param :puppet_master_ssl_client_p12 [String] pkcs12-encoded client key and certificate
       # @param :puppet_master_ssl_client_password [String] Path to file containing password for SSL client key (any format)
       # @param :puppet_master_ssl_client_auth [Boolean] Override the client-auth that is guessed from parameters
-      # @param :timeout [Fixnum] Connection timeout for Puppet master (default=PUPPET_MASTER_TIMEOUT seconds)
+      # @param :timeout [Integer] Connection timeout for Puppet master (default=PUPPET_MASTER_TIMEOUT seconds)
       def initialize(options)
         raise ArgumentError, 'Hash of options must be passed to OctocatalogDiff::Catalog::PuppetMaster' unless options.is_a?(Hash)
         raise ArgumentError, 'node must be a non-empty string' unless options[:node].is_a?(String) && options[:node] != ''

--- a/lib/octocatalog-diff/cli.rb
+++ b/lib/octocatalog-diff/cli.rb
@@ -50,7 +50,7 @@ module OctocatalogDiff
     # @param argv [Array] Use specified arguments (defaults to ARGV)
     # @param logger [Logger] Logger object
     # @param opts [Hash] Additional options
-    # @return [Fixnum] Exit code: 0=no diffs, 1=something went wrong, 2=worked but there are diffs
+    # @return [Integer] Exit code: 0=no diffs, 1=something went wrong, 2=worked but there are diffs
     def self.cli(argv = ARGV, logger = Logger.new(STDERR), opts = {})
       # Save a copy of argv to print out later in debugging
       argv_save = argv.dup

--- a/lib/octocatalog-diff/cli/options/puppet_master_timeout.rb
+++ b/lib/octocatalog-diff/cli/options/puppet_master_timeout.rb
@@ -14,7 +14,7 @@ OctocatalogDiff::Cli::Options::Option.newoption(:puppet_master_timeout) do
       cli_name: 'puppet-master-timeout',
       option_name: 'puppet_master_timeout',
       desc: 'Puppet Master catalog retrieval timeout in seconds',
-      validator: ->(x) { x.to_i > 0 || raise(ArgumentError, 'Specify timeout as a integer greater than 0') },
+      validator: ->(x) { x.to_i > 0 || raise(ArgumentError, 'Specify timeout as an integer greater than 0') },
       translator: ->(x) { x.to_i }
     )
   end

--- a/lib/octocatalog-diff/facts/puppetdb.rb
+++ b/lib/octocatalog-diff/facts/puppetdb.rb
@@ -17,7 +17,7 @@ module OctocatalogDiff
 
       # Retrieve facts from PuppetDB for a specified node.
       # @param :puppetdb_url [String|Array] => URL to PuppetDB
-      # @param :retry [Fixnum] => Retry after timeout (default 0 retries, can be more)
+      # @param :retry [Integer] => Retry after timeout (default 0 retries, can be more)
       # @param node [String] Node name. (REQUIRED for PuppetDB fact source)
       # @return [Hash] Facts
       def self.fact_retriever(options = {}, node)

--- a/lib/octocatalog-diff/puppetdb.rb
+++ b/lib/octocatalog-diff/puppetdb.rb
@@ -38,7 +38,7 @@ module OctocatalogDiff
     # Supported arguments:
     # @param :puppetdb_url [String or Array<String>] PuppetDB URL(s) to try in random order
     # @param :puppetdb_host [String] PuppetDB hostname, when constructing a URL
-    # @param :puppetdb_port [Fixnum] Port number, defaults to 8080 (non-SSL) or 8081 (SSL)
+    # @param :puppetdb_port [Integer] Port number, defaults to 8080 (non-SSL) or 8081 (SSL)
     # @param :puppetdb_ssl [Boolean] defaults to true, because you should use SSL
     # @param :puppetdb_ssl_ca [String] Path to file containing CA certificate
     # @param :puppetdb_ssl_verify [Boolean] Override the CA verification setting guessed from parameters
@@ -46,7 +46,7 @@ module OctocatalogDiff
     # @param :puppetdb_ssl_client_p12 [String] pkcs12-encoded client key and certificate
     # @param :puppetdb_ssl_client_password [String] Path to file containing password for SSL client key (any format)
     # @param :puppetdb_ssl_client_auth [Boolean] Override the client-auth that is guessed from parameters
-    # @param :timeout [Fixnum] Connection timeout for PuppetDB (default=10)
+    # @param :timeout [Integer] Connection timeout for PuppetDB (default=10)
     def initialize(options = {})
       @connections =
         if options.key?(:puppetdb_url)
@@ -149,7 +149,7 @@ module OctocatalogDiff
 
     # Parse a URL to determine hostname, port number, and whether or not SSL is used.
     # @param url [String] URL to parse
-    # @return [Hash] { ssl: true/false, host: <String>, port: <Fixnum> }
+    # @return [Hash] { ssl: true/false, host: <String>, port: <Integer> }
     def parse_url(url)
       uri = URI(url)
       raise ArgumentError, "URL #{url} has invalid scheme" unless uri.scheme =~ /^https?$/

--- a/lib/octocatalog-diff/util/catalogs.rb
+++ b/lib/octocatalog-diff/util/catalogs.rb
@@ -220,7 +220,7 @@ module OctocatalogDiff
         time_start = Time.now
         catalog.build(logger)
         time_it_took = Time.now - time_start
-        retries_str = " retries = #{catalog.retries}" if catalog.retries.is_a?(Fixnum)
+        retries_str = " retries = #{catalog.retries}" if catalog.retries.is_a?(Integer)
         time_str = "in #{time_it_took} seconds#{retries_str}"
         status_str = catalog.valid? ? 'successfully built' : 'failed'
         logger.debug "Catalog for #{opts[:branch]} #{status_str} with #{catalog.builder} #{time_str}"

--- a/spec/octocatalog-diff/fixtures/repos/fact-overrides-datatypes/modules/test/templates/test.erb
+++ b/spec/octocatalog-diff/fixtures/repos/fact-overrides-datatypes/modules/test/templates/test.erb
@@ -1,13 +1,13 @@
 my_boolean: <%= @my_boolean.class %> <%= @my_boolean.inspect %>
-my_integer: <%= @my_integer.class %> <%= @my_integer.inspect %>
+my_integer: <%= @my_integer.class.to_s == 'Integer' ? 'Fixnum' : @my_integer.class %> <%= @my_integer.inspect %>
 my_float: <%= @my_float.class %> <%= @my_float.inspect %>
-my_floating_integer: <%= @my_floating_integer.class %> <%= @my_floating_integer.inspect %>
+my_floating_integer: <%= @my_floating_integer.class.to_s == 'Integer' ? 'Fixnum' : @my_floating_integer.class %> <%= @my_floating_integer.inspect %>
 my_string: <%= @my_string.class %> <%= @my_string.inspect %>
 my_json: <%= @my_json.class %> <%= @my_json.inspect %>
 my_boolean_string: <%= @my_boolean_string.class %> <%= @my_boolean_string.inspect %>
-my_integer_string: <%= @my_integer_string.class %> <%= @my_integer_string.inspect %>
+my_integer_string: <%= @my_integer_string.class.to_s == 'Integer' ? 'Fixnum' : @my_integer_string.class %> <%= @my_integer_string.inspect %>
 my_float_string: <%= @my_float_string.class %> <%= @my_float_string.inspect %>
 real_boolean: <%= @real_boolean.class %> <%= @real_boolean.inspect %>
 real_float: <%= @real_float.class %> <%= @real_float.inspect %>
-real_integer: <%= @real_integer.class %> <%= @real_integer.inspect %>
+real_integer: <%= @real_integer.class.to_s == 'Integer' ? 'Fixnum' : @real_integer.class %> <%= @real_integer.inspect %>
 real_string: <%= @real_string.class %> <%= @real_string.inspect %>

--- a/spec/octocatalog-diff/integration/fact_override_spec.rb
+++ b/spec/octocatalog-diff/integration/fact_override_spec.rb
@@ -134,16 +134,16 @@ describe 'fact override integration' do
       pending 'catalog-diff failed' unless @result[:exitcode] == 2 && @diffs.size == 1
       file = @diffs[0][2].split(/\n/)
       expect(file).to include('my_boolean: TrueClass true')
-      expect(file).to include('my_integer: Fixnum 42')
+      expect(file).to include('my_integer: Integer 42')
       expect(file).to include('my_float: Float 3.14159')
-      expect(file).to include('my_floating_integer: Fixnum -100')
+      expect(file).to include('my_floating_integer: Integer -100')
       expect(file).to include('my_json: String "{\\"hello\\":\\"world\\"}"')
       expect(file).to include('my_boolean_string: FalseClass false')
-      expect(file).to include('my_integer_string: Fixnum 42')
+      expect(file).to include('my_integer_string: Integer 42')
       expect(file).to include('my_float_string: Float 3.14159')
       expect(file).to include('real_boolean: FalseClass false')
       expect(file).to include('real_float: Float 3.14159')
-      expect(file).to include('real_integer: Fixnum 42')
+      expect(file).to include('real_integer: Integer 42')
       expect(file).to include('real_string: String "chicken"')
     end
 
@@ -151,7 +151,7 @@ describe 'fact override integration' do
       pending 'catalog-diff failed' unless @result[:exitcode] == 2 && @diffs.size == 1
       file = @diffs[0][3].split(/\n/)
       expect(file).to include('my_boolean: TrueClass true')
-      expect(file).to include('my_integer: Fixnum 42')
+      expect(file).to include('my_integer: Integer 42')
       expect(file).to include('my_float: Float 3.14159')
       expect(file).to include('my_floating_integer: Float -100.0')
       expect(file).to include('my_json: Hash {"hello"=>"world"}')
@@ -160,7 +160,7 @@ describe 'fact override integration' do
       expect(file).to include('my_float_string: String "3.14159"')
       expect(file).to include('real_boolean: FalseClass false')
       expect(file).to include('real_float: Float 3.14159')
-      expect(file).to include('real_integer: Fixnum 42')
+      expect(file).to include('real_integer: Integer 42')
       expect(file).to include('real_string: String "chicken"')
     end
   end

--- a/spec/octocatalog-diff/integration/fact_override_spec.rb
+++ b/spec/octocatalog-diff/integration/fact_override_spec.rb
@@ -134,7 +134,7 @@ describe 'fact override integration' do
       pending 'catalog-diff failed' unless @result[:exitcode] == 2 && @diffs.size == 1
       file = @diffs[0][2].split(/\n/)
       expect(file).to include('my_boolean: TrueClass true')
-      expect(file).to include('my_integer: Integer 42')
+      expect(file).to include('my_integer: Fixnum 42')
       expect(file).to include('my_float: Float 3.14159')
       expect(file).to include('my_floating_integer: Integer -100')
       expect(file).to include('my_json: String "{\\"hello\\":\\"world\\"}"')
@@ -151,7 +151,7 @@ describe 'fact override integration' do
       pending 'catalog-diff failed' unless @result[:exitcode] == 2 && @diffs.size == 1
       file = @diffs[0][3].split(/\n/)
       expect(file).to include('my_boolean: TrueClass true')
-      expect(file).to include('my_integer: Integer 42')
+      expect(file).to include('my_integer: Fixnum 42')
       expect(file).to include('my_float: Float 3.14159')
       expect(file).to include('my_floating_integer: Float -100.0')
       expect(file).to include('my_json: Hash {"hello"=>"world"}')
@@ -160,7 +160,7 @@ describe 'fact override integration' do
       expect(file).to include('my_float_string: String "3.14159"')
       expect(file).to include('real_boolean: FalseClass false')
       expect(file).to include('real_float: Float 3.14159')
-      expect(file).to include('real_integer: Integer 42')
+      expect(file).to include('real_integer: Fixnum 42')
       expect(file).to include('real_string: String "chicken"')
     end
   end

--- a/spec/octocatalog-diff/integration/fact_override_spec.rb
+++ b/spec/octocatalog-diff/integration/fact_override_spec.rb
@@ -136,14 +136,14 @@ describe 'fact override integration' do
       expect(file).to include('my_boolean: TrueClass true')
       expect(file).to include('my_integer: Fixnum 42')
       expect(file).to include('my_float: Float 3.14159')
-      expect(file).to include('my_floating_integer: Integer -100')
+      expect(file).to include('my_floating_integer: Fixnum -100')
       expect(file).to include('my_json: String "{\\"hello\\":\\"world\\"}"')
       expect(file).to include('my_boolean_string: FalseClass false')
-      expect(file).to include('my_integer_string: Integer 42')
+      expect(file).to include('my_integer_string: Fixnum 42')
       expect(file).to include('my_float_string: Float 3.14159')
       expect(file).to include('real_boolean: FalseClass false')
       expect(file).to include('real_float: Float 3.14159')
-      expect(file).to include('real_integer: Integer 42')
+      expect(file).to include('real_integer: Fixnum 42')
       expect(file).to include('real_string: String "chicken"')
     end
 

--- a/spec/octocatalog-diff/integration/integration_helper.rb
+++ b/spec/octocatalog-diff/integration/integration_helper.rb
@@ -125,7 +125,7 @@ module OctocatalogDiff
 
         # Run the OctocatalogDiff::Cli.cli and validate output format.
         result = OctocatalogDiff::Cli.cli(argv, logger, options)
-        if result.is_a?(Fixnum)
+        if result.is_a?(Integer)
           result = OpenStruct.new(exitcode: result, exception: nil, diffs: [], to: nil, from: nil)
         elsif result.is_a?(Hash)
           result = OpenStruct.new({ exitcode: nil, exception: nil, diffs: [], to: nil, from: nil }.merge(result))

--- a/spec/octocatalog-diff/support/httparty/ssl_test_server.rb
+++ b/spec/octocatalog-diff/support/httparty/ssl_test_server.rb
@@ -29,7 +29,7 @@ class SSLTestServer
   end
 
   def stop
-    if @child_pid.is_a?(Fixnum)
+    if @child_pid.is_a?(Integer)
       begin
         Process.kill('TERM', @child_pid)
         Process.wait

--- a/spec/octocatalog-diff/tests/api/v1/override_spec.rb
+++ b/spec/octocatalog-diff/tests/api/v1/override_spec.rb
@@ -49,14 +49,20 @@ describe OctocatalogDiff::API::V1::Override do
         expect(testobj.value).to eq("foo\nbar")
       end
 
-      it 'should pass through a positive integer' do
+      it 'should pass through a positive integer using fixnum' do
         testobj = OctocatalogDiff::API::V1::Override.new(key: 'foo', value: '(fixnum)42')
         expect(testobj.key).to eq('foo')
         expect(testobj.value).to eq(42)
       end
 
+      it 'should pass through a positive integer using integer' do
+        testobj = OctocatalogDiff::API::V1::Override.new(key: 'foo', value: '(integer)42')
+        expect(testobj.key).to eq('foo')
+        expect(testobj.value).to eq(42)
+      end
+
       it 'should pass through a negative integer' do
-        testobj = OctocatalogDiff::API::V1::Override.new(key: 'foo', value: '(fixnum)-42')
+        testobj = OctocatalogDiff::API::V1::Override.new(key: 'foo', value: '(integer)-42')
         expect(testobj.key).to eq('foo')
         expect(testobj.value).to eq(-42)
       end
@@ -265,11 +271,11 @@ describe OctocatalogDiff::API::V1::Override do
       end.to raise_error(ArgumentError, /Illegal boolean 'blahblah'/)
     end
 
-    it 'should raise ArgumentError when fixnum is specified but not supplied' do
-      arg = 'key=(fixnum)blahblah'
+    it 'should raise ArgumentError when integer is specified but not supplied' do
+      arg = 'key=(integer)blahblah'
       expect do
         _foo = described_class.create_from_input(arg)
-      end.to raise_error(ArgumentError, /Illegal fixnum 'blahblah'/)
+      end.to raise_error(ArgumentError, /Illegal integer 'blahblah'/)
     end
 
     it 'should raise ArgumentError when float is specified but not supplied' do

--- a/spec/octocatalog-diff/tests/catalog-diff/display/text_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-diff/display/text_spec.rb
@@ -958,7 +958,7 @@ describe OctocatalogDiff::CatalogDiff::Display::Text do
       expect(result).to eq('hello')
     end
 
-    it 'should return the object directly if it is a fixnum' do
+    it 'should return the object directly if it is an integer' do
       result = OctocatalogDiff::CatalogDiff::Display::Text.stringify_for_diffy(42)
       expect(result).to eq(42)
     end

--- a/spec/octocatalog-diff/tests/catalog/puppetmaster_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog/puppetmaster_spec.rb
@@ -106,7 +106,8 @@ describe OctocatalogDiff::Catalog::PuppetMaster do
             # An extra 'unescape' is here because the facts are double escaped.
             # See https://docs.puppet.com/puppet/latest/http_api/http_catalog.html#parameters
             # and https://github.com/puppetlabs/puppet/pull/1818
-            result = JSON.parse(CGI.unescape(@post_data['facts']))['values']
+            data = CGI.unescape(@post_data['facts'])
+            result = JSON.parse(data)['values']
             expect(result).to eq(answer)
           end
 

--- a/spec/octocatalog-diff/tests/catalog/puppetmaster_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog/puppetmaster_spec.rb
@@ -106,7 +106,7 @@ describe OctocatalogDiff::Catalog::PuppetMaster do
             # An extra 'unescape' is here because the facts are double escaped.
             # See https://docs.puppet.com/puppet/latest/http_api/http_catalog.html#parameters
             # and https://github.com/puppetlabs/puppet/pull/1818
-            data = CGI.unescape(@post_data['facts'])
+            data = CGI.unescape(@post_data['facts'], 'UTF-8')
             result = JSON.parse(data)['values']
             expect(result).to eq(answer)
           end

--- a/spec/octocatalog-diff/tests/cli/options/puppet_master_timeout_spec.rb
+++ b/spec/octocatalog-diff/tests/cli/options/puppet_master_timeout_spec.rb
@@ -13,13 +13,13 @@ describe OctocatalogDiff::Cli::Options do
     it 'should raise error if --puppet-master-timeout == 0' do
       expect do
         run_optparse(['--puppet-master-timeout', '0'])
-      end.to raise_error(ArgumentError, 'Specify timeout as a integer greater than 0')
+      end.to raise_error(ArgumentError, 'Specify timeout as an integer greater than 0')
     end
 
     it 'should raise error if --puppet-master-timeout evaluates to 0' do
       expect do
         run_optparse(['--puppet-master-timeout', 'chickens'])
-      end.to raise_error(ArgumentError, 'Specify timeout as a integer greater than 0')
+      end.to raise_error(ArgumentError, 'Specify timeout as an integer greater than 0')
     end
 
     it 'should handle --to-puppet-master-timeout' do

--- a/spec/octocatalog-diff/tests/spec_helper.rb
+++ b/spec/octocatalog-diff/tests/spec_helper.rb
@@ -63,7 +63,7 @@ module OctocatalogDiff
     # Count the instances of a 'type' in a catalog
     # @param resources [Array] Array of resources
     # @param type [String] Type to count
-    # @return [Fixnum] Number of instances of 'type' found
+    # @return [Integer] Number of instances of 'type' found
     def self.count_by_type(resources, type)
       raise "resources is not an array; it's a(n): #{resources.class}!" unless resources.is_a?(Array)
       counter = 0


### PR DESCRIPTION
This PR makes updates to the Travis configuration and rubocop settings to be compatible with Ruby 2.4. Also, some updates in the code are made to prefer `Integer` over `Fixnum`.