### PR TITLE
Split arguments added for ENC

### DIFF
--- a/lib/octocatalog-diff/catalog-util/command.rb
+++ b/lib/octocatalog-diff/catalog-util/command.rb
@@ -68,7 +68,7 @@ module OctocatalogDiff
         # enc?
         if @options[:enc]
           raise Errno::ENOENT, "Did not find ENC as expected at #{@options[:enc]}" unless File.file?(@options[:enc])
-          cmdline << "--node_terminus=exec"
+          cmdline << '--node_terminus=exec'
           cmdline << "--external_nodes=#{Shellwords.escape(@options[:enc])}"
         end
 

--- a/lib/octocatalog-diff/catalog-util/command.rb
+++ b/lib/octocatalog-diff/catalog-util/command.rb
@@ -68,7 +68,8 @@ module OctocatalogDiff
         # enc?
         if @options[:enc]
           raise Errno::ENOENT, "Did not find ENC as expected at #{@options[:enc]}" unless File.file?(@options[:enc])
-          cmdline << "--node_terminus=exec --external_nodes=#{Shellwords.escape(@options[:enc])}"
+          cmdline << "--node_terminus=exec"
+          cmdline << "--external_nodes=#{Shellwords.escape(@options[:enc])}"
         end
 
         # Future parser?


### PR DESCRIPTION
## Overview

The arguments for puppet invocations are not longer explicitely split on
white-spaces.  This means that only one argument is added for ENC, while
this should be two (--node_terminus and --external_nodes).  Just
properly split the arguments.

## Checklist

- [ ] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [ ] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [ ] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended.
- [ ] If you have added any new gem dependencies, make sure those gems are licensed under the MIT or Apache 2.0 license. We cannot add any dependencies on gems licensed under GPL.
- [ ] If you have added any new gem dependencies, make sure you've checked in a copy of the `.gem` file into the [vendor/cache](https://github.com/github/octocatalog-diff/tree/master/vendor/cache) directory.

/cc [related issues] [teams and individuals, making sure to mention why you're CC-ing them]
