### PR TITLE
Override facts and ENC parameters identified with a regular expression

### DIFF
--- a/doc/advanced-override-facts.md
+++ b/doc/advanced-override-facts.md
@@ -65,3 +65,16 @@ The following data types in parentheses are supported:
 | `(json)` | Treat the input as a JSON string (calls `JSON.parse` in ruby) |
 | `(boolean)` | Treat the input as a boolean -- it must be `true` or `false`, case-insensitive |
 | `(nil)` | Ignore any characters after `(nil)` and deletes the fact if the fact exists |
+
+## Regular expressions
+
+If you wish to match multiple facts by pattern, specify the regular expression in place of the key name. For example:
+
+```
+octocatalog-diff -n some-node.example.com -f master -t master \
+  --to-fact-override /^ipaddress/=10.11.12.13
+```
+
+In this example, `$::ipaddress`, `$::ipaddress_eth0`, `$::ipaddress_bond0`, and any other facts starting with "ipaddress" would be overridden. However, a fact named `$::additional_ipaddress` would not be overridden, because it does not match the regular expression.
+
+Please note that you cannot *add* a fact with a regular expression -- when using regular expressions you can only modify or delete facts.

--- a/lib/octocatalog-diff/api/v1/override.rb
+++ b/lib/octocatalog-diff/api/v1/override.rb
@@ -13,7 +13,8 @@ module OctocatalogDiff
         # Constructor: Accepts a key and value.
         # @param input [Hash] Must contain :key and :value
         def initialize(input)
-          @key = input.fetch(:key)
+          key = input.fetch(:key)
+          @key = key =~ %r{\A/(.+)/\Z} ? Regexp.new(Regexp.last_match(1)) : key
           @value = parsed_value(input.fetch(:value))
         end
 
@@ -29,6 +30,7 @@ module OctocatalogDiff
           # If input is not a string, we can still construct the object if the key is given.
           # That input would come directly from code and not from the command line, since inputs
           # from the command line are always strings.
+          # Also support regular expressions for the key name, if delimited by //.
           if key.nil? && input.is_a?(String)
             unless input.include?('=')
               raise ArgumentError, "Fact override '#{input}' is not in 'key=(data type)value' format"

--- a/lib/octocatalog-diff/catalog-util/builddir.rb
+++ b/lib/octocatalog-diff/catalog-util/builddir.rb
@@ -163,9 +163,12 @@ module OctocatalogDiff
 
         if options[:fact_override].is_a?(Array)
           options[:fact_override].each do |override|
-            old_value = facts.fact(override.key)
-            facts.override(override.key, override.value)
-            logger.debug("Override #{override.key} from #{old_value.inspect} to #{override.value.inspect}")
+            keys = override.key.is_a?(Regexp) ? facts.matching(override.key) : [override.key]
+            keys.each do |key|
+              old_value = facts.fact(key)
+              facts.override(key, override.value)
+              logger.debug("Override #{key} from #{old_value.inspect} to #{override.value.inspect}")
+            end
           end
         end
 

--- a/lib/octocatalog-diff/catalog-util/enc.rb
+++ b/lib/octocatalog-diff/catalog-util/enc.rb
@@ -65,8 +65,11 @@ module OctocatalogDiff
         return unless @options[:enc_override].is_a?(Array) && @options[:enc_override].any?
         content_structure = YAML.load(content)
         @options[:enc_override].each do |x|
-          merge_enc_param(content_structure, x.key, x.value)
-          logger.debug "ENC override: #{x.key} #{x.value.nil? ? 'DELETED' : '= ' + x.value.inspect}"
+          keys = x.key.is_a?(Regexp) ? content_structure.keys.select { |y| x.key.match(y) } : [x.key]
+          keys.each do |key|
+            merge_enc_param(content_structure, key, x.value)
+            logger.debug "ENC override: #{key} #{x.value.nil? ? 'DELETED' : '= ' + x.value.inspect}"
+          end
         end
         @content = content_structure.to_yaml
       end

--- a/lib/octocatalog-diff/facts.rb
+++ b/lib/octocatalog-diff/facts.rb
@@ -120,5 +120,12 @@ module OctocatalogDiff
         @facts['values'][key] = value
       end
     end
+
+    # Find all facts matching a particular pattern
+    # @param regex [Regexp] Regular expression to match
+    # @return [Array<String>] Facts that match the regexp
+    def matching(regex)
+      @facts['values'].keys.select { |fact| regex.match(fact) }
+    end
   end
 end

--- a/spec/octocatalog-diff/tests/api/v1/override_spec.rb
+++ b/spec/octocatalog-diff/tests/api/v1/override_spec.rb
@@ -6,12 +6,18 @@ require OctocatalogDiff::Spec.require_path('/api/v1/override')
 
 describe OctocatalogDiff::API::V1::Override do
   describe '#new' do
-    it 'should raise error if fact_name is not supplied' do
+    it 'should raise error if fact name is not supplied' do
       expect { described_class.new(value: 'bar') }.to raise_error(KeyError, /key/)
     end
 
     it 'should raise error if value is not supplied' do
       expect { described_class.new(key: 'bar') }.to raise_error(KeyError, /value/)
+    end
+
+    it 'should return a regexp if fact name is a regexp' do
+      testobj = described_class.new(key: '/foo/', value: 'bar')
+      expect(testobj.key).to eq(/foo/)
+      expect(testobj.value).to eq('bar')
     end
   end
 

--- a/spec/octocatalog-diff/tests/catalog-util/enc_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-util/enc_spec.rb
@@ -167,6 +167,19 @@ describe OctocatalogDiff::CatalogUtil::ENC do
       logs = @logger_str.string.split(/\n/).compact.map { |x| OctocatalogDiff::Spec.strip_log_message(x) }
       expect(logs).to include('DEBUG - ENC override: foo = "bar"')
     end
+
+    it 'should not error if ENC regexp has ::s' do
+      options = {
+        enc_override: [OctocatalogDiff::API::V1::Override.create_from_input('/parameters::o+/=(string)bar')]
+      }
+      subject = described_class.allocate
+      subject.instance_variable_set('@options', options)
+      subject.instance_variable_set('@content', "---\nparameters:\n  foo: baz\n  fizz: buzz\n")
+      subject.send(:override_enc_parameters, @logger)
+      expect(subject.instance_variable_get('@content')).to eq("---\nparameters:\n  foo: baz\n  fizz: buzz\n")
+      logs = @logger_str.string.split(/\n/).compact.map { |x| OctocatalogDiff::Spec.strip_log_message(x) }
+      expect(logs).not_to match(/DEBUG - ENC override/)
+    end
   end
 
   describe '#merge_enc_param' do

--- a/spec/octocatalog-diff/tests/catalog-util/enc_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-util/enc_spec.rb
@@ -154,6 +154,19 @@ describe OctocatalogDiff::CatalogUtil::ENC do
       logs = @logger_str.string.split(/\n/).compact.map { |x| OctocatalogDiff::Spec.strip_log_message(x) }
       expect(logs).to include('DEBUG - ENC override: foo = "bar"')
     end
+
+    it 'should handle regexp overrides' do
+      options = {
+        enc_override: [OctocatalogDiff::API::V1::Override.create_from_input('/o+/=(string)bar')]
+      }
+      subject = described_class.allocate
+      subject.instance_variable_set('@options', options)
+      subject.instance_variable_set('@content', "---\nfoo: baz\nfizz: buzz\n")
+      subject.send(:override_enc_parameters, @logger)
+      expect(subject.instance_variable_get('@content')).to eq("---\nfoo: bar\nfizz: buzz\n")
+      logs = @logger_str.string.split(/\n/).compact.map { |x| OctocatalogDiff::Spec.strip_log_message(x) }
+      expect(logs).to include('DEBUG - ENC override: foo = "bar"')
+    end
   end
 
   describe '#merge_enc_param' do

--- a/spec/octocatalog-diff/tests/facts_spec.rb
+++ b/spec/octocatalog-diff/tests/facts_spec.rb
@@ -133,5 +133,11 @@ describe OctocatalogDiff::Facts do
         expect(result_arr[3].strip).to eq('apt_update_last_success: 1458162123')
       end
     end
+
+    describe '#matching' do
+      it 'should return facts that match the regexp' do
+        expect(@obj.matching(/(last|stamp)/)).to eq(%w[apt_update_last_success timestamp])
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR is an enhancement to the fact override and ENC override features. Before you had to type the exact name of the parameter or key to override. With this change you are allowed to enter a regular expression for the key name, and all found keys matching that regular expression will be overridden.

Example:

```
octocatalog-diff [options] --to-fact-override "/^ec2_/=(nil)" would delete all facts that start with "ec2_". 