### PR TITLE
Handle File resources with no parameters

### DIFF
--- a/lib/octocatalog-diff/catalog-util/fileresources.rb
+++ b/lib/octocatalog-diff/catalog-util/fileresources.rb
@@ -122,6 +122,7 @@ module OctocatalogDiff
       # @return [Boolean] True of resource is convertible, false if not
       def self.resource_convertible?(resource)
         return true if resource['type'] == 'File' && \
+                       !resource['parameters'].nil? && \
                        resource['parameters'].key?('source') && \
                        !resource['parameters'].key?('content') && \
                        resource['parameters']['source'] =~ %r{^puppet:///modules/([^/]+)/(.+)}


### PR DESCRIPTION


## Overview

This pull request fixes: NoMethodError: undefined method `key?' for nil:NilClass with this kind of declaration:
```puppet
file { '/path/to/purge-this-dir/except-this-file':
}
```

## Checklist

- [x] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [x] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [x] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended.
- [x] If you have added any new gem dependencies, make sure those gems are licensed under the MIT or Apache 2.0 license. We cannot add any dependencies on gems licensed under GPL.
- [x] If you have added any new gem dependencies, make sure you've checked in a copy of the `.gem` file into the [vendor/cache](https://github.com/github/octocatalog-diff/tree/master/vendor/cache) directory.