### PR TITLE
Create integration test for regressions and fix resources with no parameters

### DIFF
--- a/lib/octocatalog-diff/catalog-util/fileresources.rb
+++ b/lib/octocatalog-diff/catalog-util/fileresources.rb
@@ -122,6 +122,7 @@ module OctocatalogDiff
       # @return [Boolean] True of resource is convertible, false if not
       def self.resource_convertible?(resource)
         return true if resource['type'] == 'File' && \
+                       !resource['parameters'].nil? && \
                        resource['parameters'].key?('source') && \
                        !resource['parameters'].key?('content') && \
                        resource['parameters']['source'] =~ %r{^puppet:///modules/([^/]+)/(.+)}

--- a/spec/octocatalog-diff/fixtures/repos/regressions/README.md
+++ b/spec/octocatalog-diff/fixtures/repos/regressions/README.md
@@ -1,0 +1,5 @@
+# regressions repo fixture
+
+We occasionally encounter edge cases that don't deserve their entire fixture.
+
+We'll add them here.

--- a/spec/octocatalog-diff/fixtures/repos/regressions/hiera.yaml
+++ b/spec/octocatalog-diff/fixtures/repos/regressions/hiera.yaml
@@ -1,0 +1,9 @@
+---
+:backends:
+  - yaml
+:yaml:
+  :datadir: /var/lib/puppet/environments/%{::environment}/hieradata
+:hierarchy:
+  - common
+:merge_behavior: deeper
+:logger: console

--- a/spec/octocatalog-diff/fixtures/repos/regressions/hieradata/common.yaml
+++ b/spec/octocatalog-diff/fixtures/repos/regressions/hieradata/common.yaml
@@ -1,0 +1,3 @@
+---
+  classes:
+    - file_no_parameters

--- a/spec/octocatalog-diff/fixtures/repos/regressions/manifests/site.pp
+++ b/spec/octocatalog-diff/fixtures/repos/regressions/manifests/site.pp
@@ -1,0 +1,3 @@
+node default {
+  hiera_include('classes')
+}

--- a/spec/octocatalog-diff/fixtures/repos/regressions/modules/file_no_parameters/manifests/init.pp
+++ b/spec/octocatalog-diff/fixtures/repos/regressions/modules/file_no_parameters/manifests/init.pp
@@ -1,0 +1,5 @@
+# https://github.com/github/octocatalog-diff/pull/122
+
+class file_no_parameters {
+  file { '/tmp/foo': }
+}

--- a/spec/octocatalog-diff/integration/regressions_spec.rb
+++ b/spec/octocatalog-diff/integration/regressions_spec.rb
@@ -1,0 +1,27 @@
+# Miscellaneous regressions
+#
+# - file resource with no parameters
+#   Inspired by https://github.com/github/octocatalog-diff/pull/122
+
+# frozen_string_literal: true
+
+require_relative 'integration_helper'
+
+describe 'miscellaneous regressions' do
+  before(:all) do
+    @result = OctocatalogDiff::Integration.integration(
+      spec_repo: 'regressions',
+      spec_fact_file: 'facts.yaml',
+      argv: [
+        '--hiera-config', 'environments/production/hiera.yaml',
+        '--hiera-path-strip', '/var/lib/puppet'
+      ]
+    )
+  end
+
+  it 'should run without an error' do
+    expect(@result[:exitcode]).not_to eq(-1), "Internal error: #{OctocatalogDiff::Integration.format_exception(@result)}"
+    expect(@result[:exitcode]).to eq(0), "Runtime error: #{@result[:logs]}"
+    expect(@result[:diffs].size).to eq(0), @result[:diffs].map(&:inspect).join("\n")
+  end
+end


### PR DESCRIPTION
This PR creates a "regression" integration test, for those little bugs that we want to make sure don't appear again. The first one is courtesy of https://github.com/github/octocatalog-diff/pull/122, and the contributed fix will be merged with this PR as well.