### PR TITLE
Create and implement utility class

### DIFF
--- a/lib/octocatalog-diff/facts.rb
+++ b/lib/octocatalog-diff/facts.rb
@@ -4,6 +4,7 @@ require_relative 'errors'
 require_relative 'facts/json'
 require_relative 'facts/yaml'
 require_relative 'facts/puppetdb'
+require_relative 'util/util'
 require_relative 'external/pson/pure'
 
 module OctocatalogDiff
@@ -19,8 +20,7 @@ module OctocatalogDiff
       @timestamp = false
       @options = options.dup
       if facts
-        @facts = {}
-        facts.each { |k, v| @facts[k] = v.dup }
+        @facts = OctocatalogDiff::Util::Util.deep_dup(facts)
       else
         case options[:backend]
         when :json
@@ -32,8 +32,7 @@ module OctocatalogDiff
         else
           raise ArgumentError, 'Invalid fact source backend'
         end
-        @facts = {}
-        @orig_facts.each { |k, v| @facts[k] = v.dup }
+        @facts = OctocatalogDiff::Util::Util.deep_dup(@orig_facts)
       end
     end
 

--- a/lib/octocatalog-diff/util/util.rb
+++ b/lib/octocatalog-diff/util/util.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Handy methods that are not tied to one particular class
+
+module OctocatalogDiff
+  module Util
+    # Helper class to construct catalogs, performing all necessary steps such as
+    # bootstrapping directories, installing facts, and running puppet.
+    class Util
+      # Utility Method!
+      # `is_a?(class)` only allows one method, but this uses an array
+      # @param object [?] Object to consider
+      # @param classes [Array] Classes to determine if object is a member of
+      # @return [Boolean] True if object is_a any of the classes, false otherwise
+      def self.object_is_any_of?(object, classes)
+        classes.each { |clazz| return true if object.is_a? clazz }
+        false
+      end
+
+      # Utility Method!
+      # `.dup` can't be called on certain objects (Fixnum for example). This
+      # method returns the original object if it can't be duplicated.
+      # @param object [?] Object to consider
+      # @return [?] Duplicated object if possible, otherwise the original object
+      def self.safe_dup(object)
+        object.dup
+      rescue TypeError
+        object
+      end
+
+      # Utility Method!
+      # This does a "deep" duplication via recursion. Handles hashes and arrays.
+      # @param object [?] Object to consider
+      # @return [?] Duplicated object
+      def self.deep_dup(object)
+        if object.is_a?(Hash)
+          result = {}
+          object.each { |k, v| result[k] = deep_dup(v) }
+          result
+        elsif object.is_a?(Array)
+          object.map { |ele| deep_dup(ele) }
+        else
+          safe_dup(object)
+        end
+      end
+    end
+  end
+end

--- a/spec/octocatalog-diff/tests/util/util_spec.rb
+++ b/spec/octocatalog-diff/tests/util/util_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+require 'ostruct'
+require OctocatalogDiff::Spec.require_path('/util/util')
+
+describe OctocatalogDiff::Util::Util do
+  describe '#object_is_any_of?' do
+    it 'should return true when object is one of the classes' do
+      object = 42
+      classes = [String, Hash, Integer]
+      expect(described_class.object_is_any_of?(object, classes)).to eq(true)
+    end
+
+    it 'should return false when object is not one of the classes' do
+      object = :chickens
+      classes = [String, Hash, Integer]
+      expect(described_class.object_is_any_of?(object, classes)).to eq(false)
+    end
+  end
+
+  describe '#safe_dup' do
+    it 'should work with nil' do
+      object = nil
+      result = described_class.safe_dup(object)
+      expect(object).to eq(result)
+    end
+
+    it 'should work with a string' do
+      object = 'boots and cats'
+      result = described_class.safe_dup(object)
+      expect(object).to eq(result)
+    end
+
+    it 'should work with a symbol' do
+      object = :chickens
+      result = described_class.safe_dup(object)
+      expect(object).to eq(result)
+    end
+
+    it 'should work with an integer' do
+      object = 42
+      result = described_class.safe_dup(object)
+      expect(object).to eq(result)
+    end
+
+    it 'should work with a hash' do
+      object = { 'foo' => 'bar', 'baz' => 'buzz' }
+      result = described_class.safe_dup(object)
+      expect(object).to eq(result)
+      expect(object.object_id).not_to eq(result.object_id)
+    end
+
+    it 'should work with an array' do
+      object = %w[foo bar baz buzz]
+      result = described_class.safe_dup(object)
+      expect(object).to eq(result)
+      expect(object.object_id).not_to eq(result.object_id)
+    end
+  end
+
+  describe '#deep_dup' do
+    it 'should dupe a hash' do
+      hash1 = { 'foo' => 'bar' }
+      hash2 = { 'baz' => hash1 }
+      hash3 = { 'xxx' => hash2 }
+      result = described_class.deep_dup(hash3)
+      expect(result['xxx']).to eq(hash2)
+      expect(result['xxx'].object_id).not_to eq(hash2.object_id)
+    end
+
+    it 'should dupe an array' do
+      array1 = %w[foo bar baz]
+      array2 = ['foo', array1, 'baz']
+      array3 = ['foo', array2, 'baz']
+      result = described_class.deep_dup(array3)
+      expect(result[1]).to eq(array2)
+      expect(result[1].object_id).not_to eq(array2.object_id)
+    end
+
+    it 'should dupe a string' do
+      obj = 'Hello there'
+      result = described_class.deep_dup(obj)
+      expect(result).to eq(obj)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a utility class, with a "deep dupe" function that's used for the facts.

This work was done as part of https://github.com/github/octocatalog-diff/pull/125 to make all of the internal CI within GitHub work properly, but is separated out here for easier review.