### PR TITLE
Allow YAML facts in "facter -y" format

### DIFF
--- a/lib/octocatalog-diff/facts/yaml.rb
+++ b/lib/octocatalog-diff/facts/yaml.rb
@@ -21,8 +21,18 @@ module OctocatalogDiff
         fact_file_data = fact_file_string.split(/\n/)
         fact_file_data[0] = '---' if fact_file_data[0] =~ /^---/
 
-        # Load and return the parsed fact file.
-        result = YAML.load(fact_file_data.join("\n"))
+        # Load the parsed fact file.
+        parsed = YAML.load(fact_file_data.join("\n"))
+
+        # This is a handler for a YAML file that has just the facts and none of the
+        # structure. For example if you saved the output of `facter -y` to a file and
+        # are passing that in, this will work.
+        result = if parsed.key?('name') && parsed.key?('values')
+          parsed
+        else
+          { 'name' => node || parsed['fqdn'] || '', 'values' => parsed }
+        end
+
         result['name'] = node unless node == ''
         result
       end

--- a/spec/octocatalog-diff/fixtures/facts/unstructured.yaml
+++ b/spec/octocatalog-diff/fixtures/facts/unstructured.yaml
@@ -1,0 +1,15 @@
+---
+  apt_update_last_success: 1458162123
+  architecture: amd64
+  datacenter: xyz
+  fqdn: rspec-node.xyz.github.net
+  "_timestamp": 2014-12-02 12:56:20.865795 -08:00
+  ec2_metadata:
+    ami-id: ami-deadbeef
+    ami-launch-index: "0"
+    ami-manifest-path: "(unknown)"
+    block-device-mapping:
+      ami: /dev/sda1
+      ephemeral0: sdb
+      ephemeral1: sdc
+      root: /dev/sda1

--- a/spec/octocatalog-diff/tests/facts/yaml_spec.rb
+++ b/spec/octocatalog-diff/tests/facts/yaml_spec.rb
@@ -37,5 +37,17 @@ describe OctocatalogDiff::Facts::Yaml do
       expect(result['name']).to eq('override.node')
       expect(result['values']['fqdn']).to eq('rspec-node.xyz.github.net')
     end
+
+    it 'should convert unstructured facts into structured facts' do
+      fact_file = OctocatalogDiff::Spec.fixture_path('facts/unstructured.yaml')
+      options = {
+        fact_file_string: File.read(fact_file)
+      }
+      result = OctocatalogDiff::Facts::Yaml.fact_retriever(options, 'override.node')
+      expect(result).to be_a_kind_of(Hash)
+      expect(result['name']).to eq('override.node')
+      expect(result['values']['fqdn']).to eq('rspec-node.xyz.github.net')
+      expect(result['values']['ec2_metadata']['block-device-mapping']['ephemeral0']).to eq('sdb')
+    end
   end
 end


### PR DESCRIPTION
This PR allows fact files generated with `facter -y` to be usable by octocatalog-diff.

The facter-generated facts don't have "name" and "values" keys like Puppet facts do.