### PR TITLE
Fact file should not be global

### DIFF
--- a/lib/octocatalog-diff/cli/options/fact_file.rb
+++ b/lib/octocatalog-diff/cli/options/fact_file.rb
@@ -36,8 +36,6 @@ OctocatalogDiff::Cli::Options::Option.newoption(:fact_file) do
             break
           end
         end
-
-        options[:facts] ||= options[:to_facts]
       end
     )
   end

--- a/spec/octocatalog-diff/tests/cli/options/fact_file_spec.rb
+++ b/spec/octocatalog-diff/tests/cli/options/fact_file_spec.rb
@@ -50,6 +50,19 @@ describe OctocatalogDiff::Cli::Options do
   end
 
   describe '#opt_to_fact_file' do
+    let(:fact_file) { OctocatalogDiff::Spec.fixture_path('facts/facts.yaml') }
+    let(:fact_answer) do
+      {
+        'name' => 'rspec-node.xyz.github.net',
+        'values' => {
+          'apt_update_last_success' => 1_458_162_123,
+          'architecture' => 'amd64',
+          'datacenter' => 'xyz',
+          'fqdn' => 'rspec-node.xyz.github.net'
+        }
+      }
+    end
+
     it 'should distinguish between the to-facts and from-facts' do
       fact_file_1 = OctocatalogDiff::Spec.fixture_path('facts/facts.yaml')
       fact_file_2 = OctocatalogDiff::Spec.fixture_path('facts/valid-facts.yaml')
@@ -72,6 +85,24 @@ describe OctocatalogDiff::Cli::Options do
       expect(result_facts_2['values'].keys).not_to include('expiration')
 
       expect(result[:facts]).to eq(result[:to_facts])
+    end
+
+    it 'should only define from-fact-file when only --from-fact-file is given' do
+      result = run_optparse(['--from-fact-file', fact_file])
+      expect(result[:from_facts].facts).to eq(fact_answer)
+      expect(result[:to_facts]).to be_nil
+    end
+
+    it 'should only define to-fact-file when only --to-fact-file is given' do
+      result = run_optparse(['--from-fact-file', fact_file])
+      expect(result[:from_facts]).to be_nil
+      expect(result[:to_facts].facts).to eq(fact_answer)
+    end
+
+    it 'should define both from and to fact file when --fact-file is given' do
+      result = run_optparse(['--fact-file', fact_file])
+      expect(result[:from_facts].facts).to eq(fact_answer)
+      expect(result[:to_facts].facts).to eq(fact_answer)
     end
   end
 end

--- a/spec/octocatalog-diff/tests/cli/options/fact_file_spec.rb
+++ b/spec/octocatalog-diff/tests/cli/options/fact_file_spec.rb
@@ -51,6 +51,7 @@ describe OctocatalogDiff::Cli::Options do
 
   describe '#opt_to_fact_file' do
     let(:fact_file) { OctocatalogDiff::Spec.fixture_path('facts/facts.yaml') }
+
     let(:fact_answer) do
       {
         'name' => 'rspec-node.xyz.github.net',
@@ -92,7 +93,7 @@ describe OctocatalogDiff::Cli::Options do
     end
 
     it 'should only define to-fact-file when only --to-fact-file is given' do
-      result = run_optparse(['--from-fact-file', fact_file])
+      result = run_optparse(['--to-fact-file', fact_file])
       expect(result[:from_facts]).to be_nil
       expect(result[:to_facts].facts).to eq(fact_answer)
     end

--- a/spec/octocatalog-diff/tests/cli/options/fact_file_spec.rb
+++ b/spec/octocatalog-diff/tests/cli/options/fact_file_spec.rb
@@ -8,7 +8,7 @@ describe OctocatalogDiff::Cli::Options do
       fact_file = OctocatalogDiff::Spec.fixture_path('facts/facts.yaml')
       result = run_optparse(['--fact-file', fact_file])
       expect(result[:node]).to eq('rspec-node.xyz.github.net')
-      result_facts = result[:facts].facts
+      result_facts = result[:to_facts].facts
       expect(result_facts).to be_a_kind_of(Hash)
       expect(result_facts['name']).to eq('rspec-node.xyz.github.net')
       expect(result_facts['values']).to be_a_kind_of(Hash)
@@ -20,7 +20,7 @@ describe OctocatalogDiff::Cli::Options do
       fact_file = OctocatalogDiff::Spec.fixture_path('facts/facts.json')
       result = run_optparse(['--fact-file', fact_file])
       expect(result[:node]).to eq('rspec-node.xyz.github.net')
-      result_facts = result[:facts].facts
+      result_facts = result[:to_facts].facts
       expect(result_facts).to be_a_kind_of(Hash)
       expect(result_facts['name']).to eq('rspec-node.xyz.github.net')
       expect(result_facts['values']).to be_a_kind_of(Hash)
@@ -83,8 +83,6 @@ describe OctocatalogDiff::Cli::Options do
       expect(result_facts_2['values']['fqdn']).to eq('rspec-node.xyz.github.net')
       expect(result_facts_2['values']['ipaddress']).to eq('10.20.30.40')
       expect(result_facts_2['values'].keys).not_to include('expiration')
-
-      expect(result[:facts]).to eq(result[:to_facts])
     end
 
     it 'should only define from-fact-file when only --from-fact-file is given' do


### PR DESCRIPTION
This PR removes a bug whereby `--to-fact-file <filename>` (with no `--from-fact-file` specified) would have caused that fact file to be used for both the "from" and the "to" catalogs.