### PR TITLE
Prefix tmpdirs with ocd-

### DIFF
--- a/lib/octocatalog-diff/catalog-util/builddir.rb
+++ b/lib/octocatalog-diff/catalog-util/builddir.rb
@@ -38,7 +38,7 @@ module OctocatalogDiff
       # @param options [Hash] Options for class; see above description
       def initialize(options = {}, logger = nil)
         @options = options.dup
-        @tempdir = Dir.mktmpdir
+        @tempdir = Dir.mktmpdir('ocd-builddir-')
         at_exit { FileUtils.rm_rf(@tempdir) if File.directory?(@tempdir) }
 
         @factdir = nil

--- a/lib/octocatalog-diff/catalog/computed.rb
+++ b/lib/octocatalog-diff/catalog/computed.rb
@@ -113,7 +113,7 @@ module OctocatalogDiff
           tmphash[:basedir] = @opts[:bootstrapped_dir]
         elsif @opts[:branch] == '.'
           if @opts[:bootstrap_current]
-            tmphash[:basedir] = Dir.mktmpdir
+            tmphash[:basedir] = Dir.mktmpdir('ocd-bootstrap-basedir-')
             at_exit { cleanup_checkout_dir(tmphash[:basedir], logger) }
 
             FileUtils.cp_r File.join(@opts[:basedir], '.'), tmphash[:basedir]
@@ -124,7 +124,7 @@ module OctocatalogDiff
             tmphash[:basedir] = @opts[:basedir]
           end
         else
-          checkout_dir = Dir.mktmpdir
+          checkout_dir = Dir.mktmpdir('ocd-bootstrap-checkout-')
           at_exit { cleanup_checkout_dir(checkout_dir, logger) }
           tmphash[:basedir] = checkout_dir
           OctocatalogDiff::CatalogUtil::Bootstrap.bootstrap_directory(@opts.merge(path: checkout_dir), logger)

--- a/lib/octocatalog-diff/util/parallel.rb
+++ b/lib/octocatalog-diff/util/parallel.rb
@@ -107,7 +107,7 @@ module OctocatalogDiff
       # @return [Exception] First exception encountered by a child process; returns nil if no exceptions encountered.
       def self.run_tasks_parallel(result, task_array, logger)
         pidmap = {}
-        ipc_tempdir = Dir.mktmpdir
+        ipc_tempdir = Dir.mktmpdir('ocd-ipc-')
 
         # Child process forking
         task_array.each_with_index do |task, index|

--- a/lib/octocatalog-diff/util/scriptrunner.rb
+++ b/lib/octocatalog-diff/util/scriptrunner.rb
@@ -91,7 +91,7 @@ module OctocatalogDiff
       # @return [String] Path to tempfile containing script
       def temp_script(script)
         raise Errno::ENOENT, "Script '#{script}' not found" unless File.file?(script)
-        temp_dir = Dir.mktmpdir
+        temp_dir = Dir.mktmpdir('ocd-scriptrunner-')
         at_exit do
           begin
             FileUtils.remove_entry_secure temp_dir


### PR DESCRIPTION
To know what created a temporary directory a prefix is
a good indicator. The default of `d` is not very useful.
