### PR TITLE
Expand file text comparison to cover arrays of sources

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -8,6 +8,13 @@
 </tr>
 </thead><tbody>
 <tr valign=top>
+<td>1.4.2</td>
+<td>2017-10-16</td>
+<td>
+<li><a href="https://github.com/github/octocatalog-diff/pull/151">#151</a>: (Enhancement) Support text differences in files where `source` is an array</li>
+</td>
+</tr>
+<tr valign=top>
 <td>1.4.1</td>
 <td>2017-10-02</td>
 <td>

--- a/lib/octocatalog-diff/catalog-util/fileresources.rb
+++ b/lib/octocatalog-diff/catalog-util/fileresources.rb
@@ -27,18 +27,22 @@ module OctocatalogDiff
       # module path that is specified within the environment.conf file (assuming the default 'modules'
       # directory doesn't exist or the module isn't found in there). If the file can't be found then
       # this returns nil which may trigger an error.
-      # @param src [String] A file reference: puppet:///modules/xxx/yyy
+      # @param src_in [String|Array] A file reference: puppet:///modules/xxx/yyy
       # @param modulepaths [Array] Cached module path
       # @return [String] File system path to referenced file
-      def self.file_path(src, modulepaths)
-        unless src =~ %r{^puppet:///modules/([^/]+)/(.+)}
-          raise ArgumentError, "Bad parameter source #{src}"
+      def self.file_path(src_in, modulepaths)
+        valid_sources = [src_in].flatten.select { |line| line =~ %r{\Apuppet:///modules/([^/]+)/(.+)} }
+        unless valid_sources.any?
+          raise ArgumentError, "Bad parameter source #{src_in}"
         end
 
-        path = File.join(Regexp.last_match(1), 'files', Regexp.last_match(2))
-        modulepaths.each do |mp|
-          file = File.join(mp, path)
-          return file if File.exist?(file)
+        valid_sources.each do |src|
+          src =~ %r{\Apuppet:///modules/([^/]+)/(.+)}
+          path = File.join(Regexp.last_match(1), 'files', Regexp.last_match(2))
+          modulepaths.each do |mp|
+            file = File.join(mp, path)
+            return file if File.exist?(file)
+          end
         end
 
         nil

--- a/lib/octocatalog-diff/catalog-util/fileresources.rb
+++ b/lib/octocatalog-diff/catalog-util/fileresources.rb
@@ -32,9 +32,7 @@ module OctocatalogDiff
       # @return [String] File system path to referenced file
       def self.file_path(src_in, modulepaths)
         valid_sources = [src_in].flatten.select { |line| line =~ %r{\Apuppet:///modules/([^/]+)/(.+)} }
-        unless valid_sources.any?
-          raise ArgumentError, "Bad parameter source #{src_in}"
-        end
+        return unless valid_sources.any?
 
         valid_sources.each do |src|
           src =~ %r{\Apuppet:///modules/([^/]+)/(.+)}
@@ -129,8 +127,13 @@ module OctocatalogDiff
                        !resource['parameters'].nil? && \
                        resource['parameters'].key?('source') && \
                        !resource['parameters'].key?('content') && \
-                       resource['parameters']['source'] =~ %r{^puppet:///modules/([^/]+)/(.+)}
+                       valid_sources?(resource)
+
         false
+      end
+
+      def self.valid_sources?(resource)
+        [resource['parameters']['source']].flatten.select { |line| line =~ %r{\Apuppet:///modules/([^/]+)/(.+)} }.any?
       end
     end
   end

--- a/spec/octocatalog-diff/fixtures/repos/convert-resources/new/manifests/site.pp
+++ b/spec/octocatalog-diff/fixtures/repos/convert-resources/new/manifests/site.pp
@@ -1,3 +1,7 @@
 node default {
-  include test
+  if $::test_class {
+    include "test::${::test_class}"
+  } else {
+    include test
+  }
 }

--- a/spec/octocatalog-diff/fixtures/repos/convert-resources/new/modules/test/manifests/array1.pp
+++ b/spec/octocatalog-diff/fixtures/repos/convert-resources/new/modules/test/manifests/array1.pp
@@ -1,0 +1,8 @@
+class test::array1 {
+  file { '/tmp/foo':
+    source => [
+      'puppet:///modules/test/foo-new',
+      'puppet:///modules/test/foo-old',
+    ]
+  }
+}

--- a/spec/octocatalog-diff/fixtures/repos/convert-resources/new/modules/test/manifests/array2.pp
+++ b/spec/octocatalog-diff/fixtures/repos/convert-resources/new/modules/test/manifests/array2.pp
@@ -1,0 +1,8 @@
+class test::array2 {
+  file { '/tmp/foo':
+    source => [
+      'puppet:///modules/test/foo-bar',
+      'puppet:///modules/test/foo-new',
+    ]
+  }
+}

--- a/spec/octocatalog-diff/fixtures/repos/convert-resources/new/modules/test/manifests/array3.pp
+++ b/spec/octocatalog-diff/fixtures/repos/convert-resources/new/modules/test/manifests/array3.pp
@@ -1,0 +1,8 @@
+class test::array3 {
+  file { '/tmp/foo':
+    source => [
+      'puppet:///modules/test/foo-bar',
+      'puppet:///modules/test/foo-baz',
+    ]
+  }
+}

--- a/spec/octocatalog-diff/fixtures/repos/convert-resources/old/manifests/site.pp
+++ b/spec/octocatalog-diff/fixtures/repos/convert-resources/old/manifests/site.pp
@@ -1,3 +1,7 @@
 node default {
-  include test
+  if $::test_class {
+    include "test::${::test_class}"
+  } else {
+    include test
+  }
 }

--- a/spec/octocatalog-diff/fixtures/repos/convert-resources/old/modules/test/manifests/array1.pp
+++ b/spec/octocatalog-diff/fixtures/repos/convert-resources/old/modules/test/manifests/array1.pp
@@ -1,0 +1,8 @@
+class test::array1 {
+  file { '/tmp/foo':
+    source => [
+      'puppet:///modules/test/foo-new',
+      'puppet:///modules/test/foo-old',
+    ]
+  }
+}

--- a/spec/octocatalog-diff/fixtures/repos/convert-resources/old/modules/test/manifests/array2.pp
+++ b/spec/octocatalog-diff/fixtures/repos/convert-resources/old/modules/test/manifests/array2.pp
@@ -1,0 +1,8 @@
+class test::array2 {
+  file { '/tmp/foo':
+    source => [
+      'puppet:///modules/test/foo-bar',
+      'puppet:///modules/test/foo-old',
+    ]
+  }
+}

--- a/spec/octocatalog-diff/fixtures/repos/convert-resources/old/modules/test/manifests/array3.pp
+++ b/spec/octocatalog-diff/fixtures/repos/convert-resources/old/modules/test/manifests/array3.pp
@@ -1,0 +1,8 @@
+class test::array3 {
+  file { '/tmp/foo':
+    source => [
+      'puppet:///modules/test/foo-bar',
+      'puppet:///modules/test/foo-baz',
+    ]
+  }
+}

--- a/spec/octocatalog-diff/tests/catalog-util/fileresources_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-util/fileresources_spec.rb
@@ -22,15 +22,58 @@ describe OctocatalogDiff::CatalogUtil::FileResources do
     end
 
     it 'should return path if file is found' do
+      allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?).with('/a/foo/files/bar').and_return(true)
       result = OctocatalogDiff::CatalogUtil::FileResources.file_path('puppet:///modules/foo/bar', ['/a'])
       expect(result).to eq('/a/foo/files/bar')
     end
 
     it 'should return nil if file is not found' do
+      allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?).with('/a/foo/files/bar').and_return(false)
       result = OctocatalogDiff::CatalogUtil::FileResources.file_path('puppet:///modules/foo/bar', ['/a'])
       expect(result).to eq(nil)
+    end
+
+    it 'should return the first entry from an array if found' do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with('/a/foo/files/bar').and_return(true)
+      expect(File).not_to receive(:exist?).with('/a/foo/files/baz')
+      tries = ['puppet:///modules/foo/bar', 'puppet:///modules/foo/baz']
+      result = OctocatalogDiff::CatalogUtil::FileResources.file_path(tries, ['/a'])
+      expect(result).to eq('/a/foo/files/bar')
+    end
+
+    it 'should return the first actually found entry from an array' do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with('/a/foo/files/bar').and_return(false)
+      allow(File).to receive(:exist?).with('/a/foo/files/baz').and_return(true)
+      tries = ['sdfasdf', 'puppet:///modules/foo/bar', 'puppet:///modules/foo/baz']
+      result = OctocatalogDiff::CatalogUtil::FileResources.file_path(tries, ['/a'])
+      expect(result).to eq('/a/foo/files/baz')
+    end
+
+    it 'should return nil if no entries from an array are found' do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with('/a/foo/files/bar').and_return(false)
+      allow(File).to receive(:exist?).with('/a/foo/files/baz').and_return(false)
+      tries = ['puppet:///modules/foo/bar', 'puppet:///modules/foo/baz']
+      result = OctocatalogDiff::CatalogUtil::FileResources.file_path(tries, ['/a'])
+      expect(result).to be_nil
+    end
+
+    it 'should raise an error if the only entry is malformed' do
+      tries = 'sddfsdfsdf'
+      expect do
+        OctocatalogDiff::CatalogUtil::FileResources.file_path(tries, ['/a'])
+      end.to raise_error(ArgumentError, /Bad parameter source/)
+    end
+
+    it 'should raise an error if the all entries are malformed' do
+      tries = %w[sddfsdfsdf asdfasfdasdf]
+      expect do
+        OctocatalogDiff::CatalogUtil::FileResources.file_path(tries, ['/a'])
+      end.to raise_error(ArgumentError, /Bad parameter source/)
     end
   end
 

--- a/spec/octocatalog-diff/tests/catalog-util/fileresources_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-util/fileresources_spec.rb
@@ -14,13 +14,6 @@ describe OctocatalogDiff::CatalogUtil::FileResources do
   end
 
   describe '#file_path' do
-    it 'should raise ArgumentError for unexpected format of file name' do
-      src = 'asldfkjwoeifjslakfj'
-      expect do
-        OctocatalogDiff::CatalogUtil::FileResources.file_path(src, [])
-      end.to raise_error(ArgumentError, /Bad parameter source/)
-    end
-
     it 'should return path if file is found' do
       allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?).with('/a/foo/files/bar').and_return(true)
@@ -62,18 +55,14 @@ describe OctocatalogDiff::CatalogUtil::FileResources do
       expect(result).to be_nil
     end
 
-    it 'should raise an error if the only entry is malformed' do
+    it 'should return nil if the only entry is malformed' do
       tries = 'sddfsdfsdf'
-      expect do
-        OctocatalogDiff::CatalogUtil::FileResources.file_path(tries, ['/a'])
-      end.to raise_error(ArgumentError, /Bad parameter source/)
+      expect(OctocatalogDiff::CatalogUtil::FileResources.file_path(tries, ['/a'])).to be_nil
     end
 
-    it 'should raise an error if the all entries are malformed' do
+    it 'should return nil if the all entries are malformed' do
       tries = %w[sddfsdfsdf asdfasfdasdf]
-      expect do
-        OctocatalogDiff::CatalogUtil::FileResources.file_path(tries, ['/a'])
-      end.to raise_error(ArgumentError, /Bad parameter source/)
+      expect(OctocatalogDiff::CatalogUtil::FileResources.file_path(tries, ['/a'])).to be_nil
     end
   end
 


### PR DESCRIPTION
This PR expands the "compare file text" option, which back-fills the actual text of a file into the catalog so that comparison can occur. The change here enables arrays as well:

```
file { '/tmp/some-file.txt':
  source => ['puppet:///modules/test/some-file.txt.special', 'puppet:///modules/test/some-file.txt'], 
}
```

Fixes https://github.com/github/octocatalog-diff/issues/150