### PR TITLE
Add support for puppetdb behind basic auth

### DIFF
--- a/lib/octocatalog-diff/puppetdb.rb
+++ b/lib/octocatalog-diff/puppetdb.rb
@@ -108,6 +108,9 @@ module OctocatalogDiff
 
         begin
           more_options = { headers: { 'Accept' => 'application/json' }, timeout: @timeout }
+          if connection[:username] || connection[:password]
+            more_options[:basic_auth] = { username: connection[:username], password: connection[:password] }
+          end
           response = OctocatalogDiff::Util::HTTParty.get(complete_url, @options.merge(more_options), 'puppetdb')
 
           # Handle all non-200's from PuppetDB
@@ -153,7 +156,13 @@ module OctocatalogDiff
       end
 
       raise ArgumentError, "URL #{url} has invalid scheme" unless uri.scheme =~ /^https?$/
-      { ssl: uri.scheme == 'https', host: uri.host, port: uri.port }
+      parsed_url = { ssl: uri.scheme == 'https', host: uri.host, port: uri.port }
+      if uri.user || uri.password
+        parsed_url[:username] = uri.user
+        parsed_url[:password] = uri.password
+      end
+
+      parsed_url
     rescue URI::InvalidURIError => exc
       raise exc.class, "Invalid URL: #{url} (#{exc.message})"
     end


### PR DESCRIPTION
## Overview

This pull request adds basic auth support for puppetdb URLs.

We have a moderately unique puppet setup (though remarkably close to
github's setup, in some ways). We run puppetdb behind a proxy that is
secured with basic auth (and we will eventually be submitting patches
upstream to puppet). This commit allows octocatalog-diff to parse a basic
auth username, and password from a URL.

## Checklist

- [✓] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [✓] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [✓] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended. *(n/a)*
- [✓] If you have added any new gem dependencies, make sure those gems are licensed under the MIT or Apache 2.0 license. We cannot add any dependencies on gems licensed under GPL. *(n/a)*
- [✓] If you have added any new gem dependencies, make sure you've checked in a copy of the `.gem` file into the [vendor/cache](https://github.com/github/octocatalog-diff/tree/master/vendor/cache) directory. *(n/a)*
