### PR TITLE
Provide ordering within a given option weight

### DIFF
--- a/doc/optionsref.md
+++ b/doc/optionsref.md
@@ -87,16 +87,16 @@ Usage: octocatalog-diff [command line options]
         --to-puppet-binary STRING    Full path to puppet binary for the to branch
         --from-puppet-binary STRING  Full path to puppet binary for the from branch
         --facts-terminus STRING      Facts terminus: one of yaml, facter
+        --puppetdb-url URL           PuppetDB base URL
         --puppetdb-ssl-ca FILENAME   CA certificate that signed the PuppetDB certificate
         --puppetdb-ssl-client-cert FILENAME
                                      SSL client certificate to connect to PuppetDB
-        --puppetdb-ssl-client-password PASSWORD
-                                     Password for SSL client key to connect to PuppetDB
         --puppetdb-ssl-client-key FILENAME
                                      SSL client key to connect to PuppetDB
+        --puppetdb-ssl-client-password PASSWORD
+                                     Password for SSL client key to connect to PuppetDB
         --puppetdb-ssl-client-password-file FILENAME
                                      Read password for SSL client key from a file
-        --puppetdb-url URL           PuppetDB base URL
         --puppetdb-api-version N     Version of PuppetDB API (3 or 4)
         --fact-override STRING1[,STRING2[,...]]
                                      Override fact globally

--- a/lib/octocatalog-diff/cli/options.rb
+++ b/lib/octocatalog-diff/cli/options.rb
@@ -28,8 +28,18 @@ module OctocatalogDiff
           @weight = w
         end
 
+        def self.order_within_weight(w) # rubocop:disable Style/TrivialAccessors
+          @order_within_weight = w
+        end
+
         def self.weight
-          @weight || DEFAULT_WEIGHT
+          if @weight && @order_within_weight
+            @weight + (@order_within_weight / 100.0)
+          elsif @weight
+            @weight
+          else
+            DEFAULT_WEIGHT
+          end
         end
 
         def self.name

--- a/lib/octocatalog-diff/cli/options/puppet_master_ssl_ca.rb
+++ b/lib/octocatalog-diff/cli/options/puppet_master_ssl_ca.rb
@@ -7,6 +7,7 @@
 # @param options [Hash] Options hash being constructed; this is modified in this method.
 OctocatalogDiff::Cli::Options::Option.newoption(:puppet_master_ssl_ca) do
   has_weight 320
+  order_within_weight 30
 
   def parse(parser, options)
     OctocatalogDiff::Cli::Options.option_globally_or_per_branch(

--- a/lib/octocatalog-diff/cli/options/puppet_master_ssl_client_cert.rb
+++ b/lib/octocatalog-diff/cli/options/puppet_master_ssl_client_cert.rb
@@ -6,6 +6,7 @@
 # @param options [Hash] Options hash being constructed; this is modified in this method.
 OctocatalogDiff::Cli::Options::Option.newoption(:puppet_master_ssl_client_cert) do
   has_weight 320
+  order_within_weight 40
 
   def parse(parser, options)
     OctocatalogDiff::Cli::Options.option_globally_or_per_branch(

--- a/lib/octocatalog-diff/cli/options/puppet_master_ssl_client_key.rb
+++ b/lib/octocatalog-diff/cli/options/puppet_master_ssl_client_key.rb
@@ -6,6 +6,7 @@
 # @param options [Hash] Options hash being constructed; this is modified in this method.
 OctocatalogDiff::Cli::Options::Option.newoption(:puppet_master_ssl_client_key) do
   has_weight 320
+  order_within_weight 50
 
   def parse(parser, options)
     OctocatalogDiff::Cli::Options.option_globally_or_per_branch(

--- a/lib/octocatalog-diff/cli/options/puppetdb_ssl_ca.rb
+++ b/lib/octocatalog-diff/cli/options/puppetdb_ssl_ca.rb
@@ -7,6 +7,7 @@
 # @param options [Hash] Options hash being constructed; this is modified in this method.
 OctocatalogDiff::Cli::Options::Option.newoption(:puppetdb_ssl_ca) do
   has_weight 310
+  order_within_weight 10
 
   def parse(parser, options)
     parser.on('--puppetdb-ssl-ca FILENAME', 'CA certificate that signed the PuppetDB certificate') do |x|

--- a/lib/octocatalog-diff/cli/options/puppetdb_ssl_client_cert.rb
+++ b/lib/octocatalog-diff/cli/options/puppetdb_ssl_client_cert.rb
@@ -6,6 +6,7 @@
 # @param options [Hash] Options hash being constructed; this is modified in this method.
 OctocatalogDiff::Cli::Options::Option.newoption(:puppetdb_ssl_client_cert) do
   has_weight 310
+  order_within_weight 20
 
   def parse(parser, options)
     parser.on('--puppetdb-ssl-client-cert FILENAME', 'SSL client certificate to connect to PuppetDB') do |x|

--- a/lib/octocatalog-diff/cli/options/puppetdb_ssl_client_key.rb
+++ b/lib/octocatalog-diff/cli/options/puppetdb_ssl_client_key.rb
@@ -6,6 +6,7 @@
 # @param options [Hash] Options hash being constructed; this is modified in this method.
 OctocatalogDiff::Cli::Options::Option.newoption(:puppetdb_ssl_client_key) do
   has_weight 310
+  order_within_weight 30
 
   def parse(parser, options)
     parser.on('--puppetdb-ssl-client-key FILENAME', 'SSL client key to connect to PuppetDB') do |x|

--- a/lib/octocatalog-diff/cli/options/puppetdb_ssl_client_password.rb
+++ b/lib/octocatalog-diff/cli/options/puppetdb_ssl_client_password.rb
@@ -7,6 +7,7 @@
 # @param options [Hash] Options hash being constructed; this is modified in this method.
 OctocatalogDiff::Cli::Options::Option.newoption(:puppetdb_ssl_client_cert) do
   has_weight 310
+  order_within_weight 35
 
   def parse(parser, options)
     parser.on('--puppetdb-ssl-client-password PASSWORD', 'Password for SSL client key to connect to PuppetDB') do |x|

--- a/lib/octocatalog-diff/cli/options/puppetdb_ssl_client_password_file.rb
+++ b/lib/octocatalog-diff/cli/options/puppetdb_ssl_client_password_file.rb
@@ -5,6 +5,7 @@
 # @param options [Hash] Options hash being constructed; this is modified in this method.
 OctocatalogDiff::Cli::Options::Option.newoption(:puppetdb_ssl_client_password_file) do
   has_weight 310
+  order_within_weight 37
 
   def parse(parser, options)
     parser.on('--puppetdb-ssl-client-password-file FILENAME', 'Read password for SSL client key from a file') do |x|

--- a/lib/octocatalog-diff/cli/options/puppetdb_url.rb
+++ b/lib/octocatalog-diff/cli/options/puppetdb_url.rb
@@ -7,6 +7,7 @@ require 'uri'
 # @param options [Hash] Options hash being constructed; this is modified in this method.
 OctocatalogDiff::Cli::Options::Option.newoption(:puppetdb_url) do
   has_weight 310
+  order_within_weight 1
 
   def parse(parser, options)
     parser.on('--puppetdb-url URL', 'PuppetDB base URL') do |url|


### PR DESCRIPTION
Some options have the same weight, and updating the document was causing flapping in the ordering of the options. This PR adds an additional sub-weight within a group of weighted options to keep ordering consistent. This is implemented across the puppet and puppetDB SSL credential options.