### PR TITLE
Add integration test for CLI fact override being used over config file

### DIFF
--- a/lib/octocatalog-diff/catalog-util/builddir.rb
+++ b/lib/octocatalog-diff/catalog-util/builddir.rb
@@ -149,13 +149,13 @@ module OctocatalogDiff
           raise ArgumentError, 'Called install_fact_file without node, or with an empty node'
         end
 
-        facts = if options[:fact_file]
+        facts = if options[:facts].is_a?(OctocatalogDiff::Facts)
+          options[:facts].dup
+        elsif options[:fact_file]
           raise Errno::ENOENT, "Fact file #{options[:fact_file]} does not exist" unless File.file?(options[:fact_file])
           fact_file_opts = { fact_file_string: File.read(options[:fact_file]) }
           fact_file_opts[:backend] = Regexp.last_match(1).to_sym if options[:fact_file] =~ /.*\.(\w+)$/
           OctocatalogDiff::Facts.new(fact_file_opts)
-        elsif options[:facts].is_a?(OctocatalogDiff::Facts)
-          options[:facts].dup
         else
           raise ArgumentError, 'No facts passed to "install_fact_file" method'
         end

--- a/spec/octocatalog-diff/fixtures/cli-configs/fact-file.rb
+++ b/spec/octocatalog-diff/fixtures/cli-configs/fact-file.rb
@@ -1,0 +1,14 @@
+# This is a configuration file for octocatalog-diff
+
+module OctocatalogDiff
+  class Config
+    def self.config
+      {
+        facts: OctocatalogDiff::Facts.new(
+          backend: :yaml,
+          fact_file_string: File.read(File.join(ENV['PUPPET_FACT_FILE_DIR'], 'valid-facts.yaml'))
+        )
+      }
+    end
+  end
+end

--- a/spec/octocatalog-diff/fixtures/cli-configs/fact-file.rb
+++ b/spec/octocatalog-diff/fixtures/cli-configs/fact-file.rb
@@ -7,7 +7,8 @@ module OctocatalogDiff
         facts: OctocatalogDiff::Facts.new(
           backend: :yaml,
           fact_file_string: File.read(File.join(ENV['PUPPET_FACT_FILE_DIR'], 'valid-facts.yaml'))
-        )
+        ),
+        fact_file: File.join(ENV['PUPPET_FACT_FILE_DIR'], 'valid-facts.yaml')
       }
     end
   end

--- a/spec/octocatalog-diff/integration/fact_file_by_branch_spec.rb
+++ b/spec/octocatalog-diff/integration/fact_file_by_branch_spec.rb
@@ -142,3 +142,60 @@ describe 'fact files by branch, with only a from fact file' do
     expect(@result.stderr).to match(/Diffs computed for rspec-node.github.net/)
   end
 end
+
+describe 'fact file from the configuration' do
+  before(:all) do
+    ENV['PUPPET_FACT_FILE_DIR'] = OctocatalogDiff::Spec.fixture_path('facts')
+    @result = OctocatalogDiff::Integration.integration_cli(
+      [
+        '-n', 'rspec-node.github.net',
+        '--bootstrapped-to-dir', OctocatalogDiff::Spec.fixture_path('repos/fact-overrides'),
+        '--catalog-only',
+        '--puppet-binary', OctocatalogDiff::Spec::PUPPET_BINARY,
+        '-d'
+      ],
+      OctocatalogDiff::Spec.fixture_path('cli-configs/fact-file.rb')
+    )
+  end
+
+  after(:all) do
+    ENV.delete('PUPPET_FACT_FILE_DIR')
+  end
+
+  it 'should exit with status 0' do
+    expect(@result.exitcode).to eq(0), @result.stderr
+  end
+
+  it 'should contain resources generated from the proper fact file' do
+    expect(@result.stdout).to match(/"10.20.30.40"/)
+  end
+end
+
+describe 'fact file overridden on the command line' do
+  before(:all) do
+    ENV['PUPPET_FACT_FILE_DIR'] = OctocatalogDiff::Spec.fixture_path('facts')
+    @result = OctocatalogDiff::Integration.integration_cli(
+      [
+        '-n', 'rspec-node.github.net',
+        '--bootstrapped-to-dir', OctocatalogDiff::Spec.fixture_path('repos/fact-overrides'),
+        '--catalog-only',
+        '--puppet-binary', OctocatalogDiff::Spec::PUPPET_BINARY,
+        '-d',
+        '--fact-file', OctocatalogDiff::Spec.fixture_path('facts/valid-facts-different-ip.yaml')
+      ],
+      OctocatalogDiff::Spec.fixture_path('cli-configs/fact-file.rb')
+    )
+  end
+
+  after(:all) do
+    ENV.delete('PUPPET_FACT_FILE_DIR')
+  end
+
+  it 'should exit with status 0' do
+    expect(@result.exitcode).to eq(0), @result.stderr
+  end
+
+  it 'should contain resources generated from the proper fact file' do
+    expect(@result.stdout).to match(/"10.30.50.70"/)
+  end
+end

--- a/spec/octocatalog-diff/integration/fact_file_by_branch_spec.rb
+++ b/spec/octocatalog-diff/integration/fact_file_by_branch_spec.rb
@@ -167,7 +167,7 @@ describe 'fact file from the configuration' do
   end
 
   it 'should contain resources generated from the proper fact file' do
-    expect(@result.stdout).to match(/"10.20.30.40"/)
+    expect(@result.stdout).to match(/"10\.20\.30\.40"/)
   end
 end
 
@@ -196,6 +196,6 @@ describe 'fact file overridden on the command line' do
   end
 
   it 'should contain resources generated from the proper fact file' do
-    expect(@result.stdout).to match(/"10.30.50.70"/)
+    expect(@result.stdout).to match(/"10\.30\.50\.70"/)
   end
 end

--- a/spec/octocatalog-diff/integration/integration_helper.rb
+++ b/spec/octocatalog-diff/integration/integration_helper.rb
@@ -31,10 +31,10 @@ module OctocatalogDiff
     end
 
     # For an integration test, run the full CLI and get results
-    def self.integration_cli(argv)
+    def self.integration_cli(argv, override_env = nil)
       script = File.expand_path('../../../bin/octocatalog-diff', File.dirname(__FILE__))
       cmdline = [script, argv].flatten.map { |x| Shellwords.escape(x) }.join(' ')
-      env = { 'OCTOCATALOG_DIFF_CONFIG_FILE' => OctocatalogDiff::Spec.fixture_path('cli-configs/no-op.rb') }
+      env = { 'OCTOCATALOG_DIFF_CONFIG_FILE' => override_env || OctocatalogDiff::Spec.fixture_path('cli-configs/no-op.rb') }
       stdout, stderr, status = Open3.capture3(env, cmdline)
       OpenStruct.new(
         stdout: stdout,


### PR DESCRIPTION
This PR adds an integration test to ensure that command line arguments `--to-fact-file` and `--from-fact-file` override any facts that were specified in the `.octocatalog-diff.cfg.rb` file. The bug where `:fact_file` in the settings took precedence over a command-line override for facts is also fixed here.

Fixes https://github.com/github/octocatalog-diff/issues/139.