### PR TITLE
Add filter to treat an object the same as a single array containing that object

### DIFF
--- a/lib/octocatalog-diff/catalog-diff/filter.rb
+++ b/lib/octocatalog-diff/catalog-diff/filter.rb
@@ -2,6 +2,7 @@ require_relative '../api/v1/diff'
 require_relative 'filter/absent_file'
 require_relative 'filter/compilation_dir'
 require_relative 'filter/json'
+require_relative 'filter/single_item_array'
 require_relative 'filter/yaml'
 
 require 'stringio'
@@ -13,7 +14,7 @@ module OctocatalogDiff
       attr_accessor :logger
 
       # List the available filters here (by class name) for use in the validator method.
-      AVAILABLE_FILTERS = %w(AbsentFile CompilationDir JSON YAML).freeze
+      AVAILABLE_FILTERS = %w(AbsentFile CompilationDir JSON SingleItemArray YAML).freeze
 
       # Public: Determine whether a particular filter exists. This can be used to validate
       # a user-submitted filter.

--- a/lib/octocatalog-diff/catalog-diff/filter/single_item_array.rb
+++ b/lib/octocatalog-diff/catalog-diff/filter/single_item_array.rb
@@ -2,8 +2,6 @@
 
 require_relative '../filter'
 
-require 'set'
-
 module OctocatalogDiff
   module CatalogDiff
     class Filter

--- a/lib/octocatalog-diff/catalog-diff/filter/single_item_array.rb
+++ b/lib/octocatalog-diff/catalog-diff/filter/single_item_array.rb
@@ -7,8 +7,8 @@ require 'set'
 module OctocatalogDiff
   module CatalogDiff
     class Filter
-      # Filter out changes in parameters when one catalog has a parameter that's a string and
-      # the other catalog has that same parameter as an array containing the same string.
+      # Filter out changes in parameters when one catalog has a parameter that's an object and
+      # the other catalog has that same parameter as an array containing the same object.
       # For example, under this filter, the following is not a change:
       #   catalog1: notify => "Service[foo]"
       #   catalog2: notify => ["Service[foo]"]
@@ -18,9 +18,27 @@ module OctocatalogDiff
         #
         # @param diff [OctocatalogDiff::API::V1::Diff] Difference
         # @param _options [Hash] Additional options (there are none for this filter)
-        # @return [Boolean] true if this difference is a YAML file with identical objects, false otherwise
-        def filtered?(_diff, _options = {})
-          false
+        # @return [Boolean] true if this should be filtered out, false otherwise
+        def filtered?(diff, _options = {})
+          # Skip additions or removals - focus only on changes
+          return false unless diff.change?
+          old_value = diff.old_value
+          new_value = diff.new_value
+
+          # Skip unless there is a single-item array under consideration
+          return false unless
+            (old_value.is_a?(Array) && old_value.size == 1) ||
+            (new_value.is_a?(Array) && new_value.size == 1)
+
+          # Skip if both the old value and new value are arrays
+          return false if old_value.is_a?(Array) && new_value.is_a?(Array)
+
+          # Do comparison
+          if old_value.is_a?(Array)
+            old_value.first == new_value
+          else
+            new_value.first == old_value
+          end
         end
       end
     end

--- a/lib/octocatalog-diff/catalog-diff/filter/single_item_array.rb
+++ b/lib/octocatalog-diff/catalog-diff/filter/single_item_array.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative '../filter'
+
+require 'set'
+
+module OctocatalogDiff
+  module CatalogDiff
+    class Filter
+      # Filter out changes in parameters when one catalog has a parameter that's a string and
+      # the other catalog has that same parameter as an array containing the same string.
+      # For example, under this filter, the following is not a change:
+      #   catalog1: notify => "Service[foo]"
+      #   catalog2: notify => ["Service[foo]"]
+      class SingleItemArray < OctocatalogDiff::CatalogDiff::Filter
+        # Public: Implement the filter for single-item arrays whose item exactly matches the
+        # item that's not in an array in the other catalog.
+        #
+        # @param diff [OctocatalogDiff::API::V1::Diff] Difference
+        # @param _options [Hash] Additional options (there are none for this filter)
+        # @return [Boolean] true if this difference is a YAML file with identical objects, false otherwise
+        def filtered?(_diff, _options = {})
+          false
+        end
+      end
+    end
+  end
+end

--- a/spec/octocatalog-diff/fixtures/catalogs/filter-single-item-array-1.json
+++ b/spec/octocatalog-diff/fixtures/catalogs/filter-single-item-array-1.json
@@ -1,0 +1,77 @@
+{
+  "document_type": "Catalog",
+  "data": {
+    "tags": [
+      "settings"
+    ],
+    "name": "my.rspec.node",
+    "version": "production",
+    "environment": "production",
+    "resources": [
+      {
+        "type": "File",
+        "title": "/tmp/amazing",
+        "file": "/environments/production/modules/foo/manifests/init.pp",
+        "line": 10,
+        "exported": false,
+        "parameters": {
+          "content": "This is my file.\nMy file is amazing.\n",
+          "group": "root",
+          "mode": "0755",
+          "notify": "Service[foo]",
+          "owner": "root"
+        }
+      },
+      {
+        "type": "File",
+        "title": "/tmp/awesome",
+        "file": "/environments/production/modules/foo/manifests/init.pp",
+        "line": 20,
+        "exported": false,
+        "parameters": {
+          "content": "This is my file.\nMy file is awesome.\n",
+          "group": "root",
+          "mode": "0755",
+          "notify": [
+            "Service[foo]",
+            "Service[bar]"
+          ],
+          "owner": "root"
+        }
+      },
+      {
+        "type": "File",
+        "title": "/tmp/fizzbuzz",
+        "file": "/environments/production/modules/foo/manifests/init.pp",
+        "line": 30,
+        "exported": false,
+        "parameters": {
+          "content": "1\n2\nfizz\n4\nbuzz\nfizz\n7\n8\nfizz\nbuzz\n",
+          "group": "root",
+          "mode": "0755",
+          "owner": "root"
+        }
+      },
+      {
+        "type": "File",
+        "title": "/tmp/foobar",
+        "file": "/environments/production/modules/foo/manifests/init.pp",
+        "line": 40,
+        "exported": false,
+        "parameters": {
+          "content": "foo\nbar\n",
+          "group": "root",
+          "mode": "0755",
+          "owner": "root",
+          "notify": "Service[foobar]"
+        }
+      }
+    ],
+    "classes": [
+      "settings"
+    ]
+  },
+  "metadata": {
+    "api_version": 1
+  }
+}

--- a/spec/octocatalog-diff/fixtures/catalogs/filter-single-item-array-1.json
+++ b/spec/octocatalog-diff/fixtures/catalogs/filter-single-item-array-1.json
@@ -36,7 +36,10 @@
             "Service[foo]",
             "Service[bar]"
           ],
-          "owner": "root"
+          "owner": "root",
+          "subscribe": [
+            "Service[baz]"
+          ]
         }
       },
       {

--- a/spec/octocatalog-diff/fixtures/catalogs/filter-single-item-array-2.json
+++ b/spec/octocatalog-diff/fixtures/catalogs/filter-single-item-array-2.json
@@ -1,0 +1,85 @@
+{
+  "document_type": "Catalog",
+  "data": {
+    "tags": [
+      "settings"
+    ],
+    "name": "my.rspec.node",
+    "version": "production",
+    "environment": "production",
+    "resources": [
+      {
+        "type": "File",
+        "title": "/tmp/amazing",
+        "file": "/environments/production/modules/foo/manifests/init.pp",
+        "line": 10,
+        "exported": false,
+        "parameters": {
+          "content": "This is my file.\nMy file is amazing.\n",
+          "group": "root",
+          "mode": "0755",
+          "notify": [
+            "Service[foo]"
+          ],
+          "owner": "root"
+        }
+      },
+      {
+        "type": "File",
+        "title": "/tmp/awesome",
+        "file": "/environments/production/modules/foo/manifests/init.pp",
+        "line": 20,
+        "exported": false,
+        "parameters": {
+          "content": "This is my file.\nMy file is awesome.\n",
+          "group": "root",
+          "mode": "0755",
+          "notify": [
+            "Service[foo]",
+            "Service[baz]"
+          ],
+          "owner": "root"
+        }
+      },
+      {
+        "type": "File",
+        "title": "/tmp/fizzbuzz",
+        "file": "/environments/production/modules/foo/manifests/init.pp",
+        "line": 30,
+        "exported": false,
+        "parameters": {
+          "content": "1\n2\nfizz\n4\nbuzz\nfizz\n7\n8\nfizz\nbuzz\n",
+          "group": "root",
+          "mode": "0755",
+          "owner": "root",
+          "notify": [
+            "Service[fizzbuzz]"
+          ]
+        }
+      },
+      {
+        "type": "File",
+        "title": "/tmp/foobar",
+        "file": "/environments/production/modules/foo/manifests/init.pp",
+        "line": 40,
+        "exported": false,
+        "parameters": {
+          "content": "foo\nbar\n",
+          "group": "root",
+          "mode": "0755",
+          "owner": "root",
+          "notify": [
+            "Service[fizzbuzz]",
+            "Service[foobar]"
+          ]
+        }
+      }
+    ],
+    "classes": [
+      "settings"
+    ]
+  },
+  "metadata": {
+    "api_version": 1
+  }
+}

--- a/spec/octocatalog-diff/fixtures/catalogs/filter-single-item-array-2.json
+++ b/spec/octocatalog-diff/fixtures/catalogs/filter-single-item-array-2.json
@@ -38,7 +38,10 @@
             "Service[foo]",
             "Service[baz]"
           ],
-          "owner": "root"
+          "owner": "root",
+          "subscribe": [
+            "Service[baz]"
+          ]
         }
       },
       {

--- a/spec/octocatalog-diff/integration/filter_single_item_array.rb
+++ b/spec/octocatalog-diff/integration/filter_single_item_array.rb
@@ -45,4 +45,48 @@ describe 'filter single-item arrays' do
       )
     end
   end
+
+  context 'with single-item array filter engaged' do
+    before(:all) do
+      @result = OctocatalogDiff::Integration.integration(
+        spec_catalog_old: 'filter-single-item-array-1.json',
+        spec_catalog_new: 'filter-single-item-array-2.json',
+        argv: ['--filters', 'SingleItemArray']
+      )
+      @diffs = OctocatalogDiff::Spec.remove_file_and_line(@result[:diffs])
+    end
+
+    it 'should succeed' do
+      expect(@result[:exitcode]).not_to eq(-1), "Internal error: #{@result[:exception]}\n#{@result[:logs]}"
+      expect(@result[:exitcode]).to eq(2), "Runtime error: #{@result[:logs]}"
+    end
+
+    it 'should contain the correct number of diffs' do
+      expect(@diffs.size).to eq(3), @diffs.inspect
+    end
+
+    it 'should suppress a diff of a string to a single-item array' do
+      expect(@diffs).not_to include(
+        ['~', "File\f/tmp/amazing\fparameters\fnotify", 'Service[foo]', ['Service[foo]']]
+      )
+    end
+
+    it 'should contain a diff of an array whose size has changed' do
+      expect(@diffs).to include(
+        ['~', "File\f/tmp/foobar\fparameters\fnotify", 'Service[foobar]', ['Service[fizzbuzz]', 'Service[foobar]']]
+      )
+    end
+
+    it 'should contain a diff of an array whose elements have changed' do
+      expect(@diffs).to include(
+        ['!', "File\f/tmp/awesome\fparameters\fnotify", ['Service[bar]', 'Service[foo]'], ['Service[baz]', 'Service[foo]']]
+      )
+    end
+
+    it 'should contain a diff of an array that has been added' do
+      expect(@diffs).to include(
+        ['!', "File\f/tmp/fizzbuzz\fparameters\fnotify", nil, ['Service[fizzbuzz]']]
+      )
+    end
+  end
 end

--- a/spec/octocatalog-diff/integration/filter_single_item_array.rb
+++ b/spec/octocatalog-diff/integration/filter_single_item_array.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require_relative 'integration_helper'
+
+describe 'filter single-item arrays' do
+  context 'with default behavior' do
+    before(:all) do
+      @result = OctocatalogDiff::Integration.integration(
+        spec_catalog_old: 'filter-single-item-array-1.json',
+        spec_catalog_new: 'filter-single-item-array-2.json'
+      )
+      @diffs = OctocatalogDiff::Spec.remove_file_and_line(@result[:diffs])
+    end
+
+    it 'should succeed' do
+      expect(@result[:exitcode]).not_to eq(-1), "Internal error: #{@result[:exception]}\n#{@result[:logs]}"
+      expect(@result[:exitcode]).to eq(2), "Runtime error: #{@result[:logs]}"
+    end
+
+    it 'should contain the correct number of diffs' do
+      expect(@diffs.size).to eq(4), @diffs.inspect
+    end
+
+    it 'should contain a diff of a string to a single-item array' do
+      expect(@diffs).to include(
+        ['~', "File\f/tmp/amazing\fparameters\fnotify", 'Service[foo]', ['Service[foo]']]
+      )
+    end
+
+    it 'should contain a diff of an array whose size has changed' do
+      expect(@diffs).to include(
+        ['~', "File\f/tmp/foobar\fparameters\fnotify", 'Service[foobar]', ['Service[fizzbuzz]', 'Service[foobar]']]
+      )
+    end
+
+    it 'should contain a diff of an array whose elements have changed' do
+      expect(@diffs).to include(
+        ['!', "File\f/tmp/awesome\fparameters\fnotify", ['Service[bar]', 'Service[foo]'], ['Service[baz]', 'Service[foo]']]
+      )
+    end
+
+    it 'should contain a diff of an array that has been added' do
+      expect(@diffs).to include(
+        ['!', "File\f/tmp/fizzbuzz\fparameters\fnotify", nil, ['Service[fizzbuzz]']]
+      )
+    end
+  end
+end

--- a/spec/octocatalog-diff/tests/catalog-diff/filter/single_item_array_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-diff/filter/single_item_array_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+require OctocatalogDiff::Spec.require_path('/api/v1/diff')
+require OctocatalogDiff::Spec.require_path('/catalog-diff/filter/single_item_array')
+
+describe OctocatalogDiff::CatalogDiff::Filter::SingleItemArray do
+  let(:subject) { described_class.new }
+
+  describe '#filtered?' do
+    it 'should not filter out an added resource' do
+      diff = ['+', "File\ffoobar.json", { 'parameters' => { 'content' => '{"foo":"bar"}' } }]
+      diff_obj = OctocatalogDiff::API::V1::Diff.new(diff)
+      result = subject.filtered?(diff_obj)
+      expect(result).to eq(false)
+    end
+
+    it 'should not filter out a removed resource' do
+      diff = ['-', "File\ffoobar.json", { 'parameters' => { 'content' => '{"foo":"bar"}' } }]
+      diff_obj = OctocatalogDiff::API::V1::Diff.new(diff)
+      result = subject.filtered?(diff_obj)
+      expect(result).to eq(false)
+    end
+
+    it 'should filter when from-catalog has string and to-catalog has array with that string' do
+      diff = [
+        '~',
+        "File\ffoobar.json",
+        { 'parameters' => { 'notify' => 'Service[foo]' } },
+        { 'parameters' => { 'notify' => ['Service[foo]'] } }
+      ]
+      diff_obj = OctocatalogDiff::API::V1::Diff.new(diff)
+      result = subject.filtered?(diff_obj)
+      expect(result).to eq(true)
+    end
+  end
+end

--- a/spec/octocatalog-diff/tests/catalog-diff/filter/single_item_array_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-diff/filter/single_item_array_spec.rb
@@ -25,9 +25,9 @@ describe OctocatalogDiff::CatalogDiff::Filter::SingleItemArray do
     it 'should filter when from-catalog has string and to-catalog has array with that string' do
       diff = [
         '~',
-        "File\ffoobar.json",
-        { 'parameters' => { 'notify' => 'Service[foo]' } },
-        { 'parameters' => { 'notify' => ['Service[foo]'] } }
+        "File\ffoobar.json\fparameters\fnotify",
+        'Service[foo]',
+        ['Service[foo]']
       ]
       diff_obj = OctocatalogDiff::API::V1::Diff.new(diff)
       result = subject.filtered?(diff_obj)
@@ -37,9 +37,9 @@ describe OctocatalogDiff::CatalogDiff::Filter::SingleItemArray do
     it 'should filter when to-catalog has string and from-catalog has array with that string' do
       diff = [
         '~',
-        "File\ffoobar.json",
-        { 'parameters' => { 'notify' => ['Service[foo]'] } },
-        { 'parameters' => { 'notify' => 'Service[foo]' } }
+        "File\ffoobar.json\fparameters\fnotify",
+        ['Service[foo]'],
+        'Service[foo]'
       ]
       diff_obj = OctocatalogDiff::API::V1::Diff.new(diff)
       result = subject.filtered?(diff_obj)
@@ -49,9 +49,9 @@ describe OctocatalogDiff::CatalogDiff::Filter::SingleItemArray do
     it 'should not filter when from-catalog has string and to-catalog has array with a different string' do
       diff = [
         '~',
-        "File\ffoobar.json",
-        { 'parameters' => { 'notify' => 'Service[bar]' } },
-        { 'parameters' => { 'notify' => ['Service[foo]'] } }
+        "File\ffoobar.json\fparameters\fnotify",
+        'Service[bar]',
+        ['Service[foo]']
       ]
       diff_obj = OctocatalogDiff::API::V1::Diff.new(diff)
       result = subject.filtered?(diff_obj)
@@ -61,9 +61,9 @@ describe OctocatalogDiff::CatalogDiff::Filter::SingleItemArray do
     it 'should not filter when to-catalog has string and from-catalog has array with a different string' do
       diff = [
         '~',
-        "File\ffoobar.json",
-        { 'parameters' => { 'notify' => ['Service[foo]'] } },
-        { 'parameters' => { 'notify' => 'Service[bar]' } }
+        "File\ffoobar.json\fparameters\fnotify",
+        ['Service[foo]'],
+        'Service[bar]'
       ]
       diff_obj = OctocatalogDiff::API::V1::Diff.new(diff)
       result = subject.filtered?(diff_obj)
@@ -73,9 +73,9 @@ describe OctocatalogDiff::CatalogDiff::Filter::SingleItemArray do
     it 'should not filter when both of the items are arrays' do
       diff = [
         '~',
-        "File\ffoobar.json",
-        { 'parameters' => { 'notify' => ['Service[bar]'] } },
-        { 'parameters' => { 'notify' => ['Service[foo]'] } }
+        "File\ffoobar.json\fparameters\fnotify",
+        ['Service[foo]'],
+        ['Service[bar]']
       ]
       diff_obj = OctocatalogDiff::API::V1::Diff.new(diff)
       result = subject.filtered?(diff_obj)
@@ -86,9 +86,9 @@ describe OctocatalogDiff::CatalogDiff::Filter::SingleItemArray do
       # This diff should never be produced by the program, but catch the edge case anyway.
       diff = [
         '~',
-        "File\ffoobar.json",
-        { 'parameters' => { 'notify' => ['Service[foo]'] } },
-        { 'parameters' => { 'notify' => ['Service[foo]'] } }
+        "File\ffoobar.json\fparameters\fnotify",
+        ['Service[foo]'],
+        ['Service[foo]']
       ]
       diff_obj = OctocatalogDiff::API::V1::Diff.new(diff)
       result = subject.filtered?(diff_obj)
@@ -99,9 +99,9 @@ describe OctocatalogDiff::CatalogDiff::Filter::SingleItemArray do
       # This diff should never be produced by the program, but catch the edge case anyway.
       diff = [
         '~',
-        "File\ffoobar.json",
-        { 'parameters' => { 'notify' => 'Service[foo]' } },
-        { 'parameters' => { 'notify' => 'Service[foo]' } }
+        "File\ffoobar.json\fparameters\fnotify",
+        'Service[foo]',
+        'Service[foo]'
       ]
       diff_obj = OctocatalogDiff::API::V1::Diff.new(diff)
       result = subject.filtered?(diff_obj)
@@ -112,8 +112,9 @@ describe OctocatalogDiff::CatalogDiff::Filter::SingleItemArray do
       diff = [
         '~',
         "File\ffoobar.json",
-        { 'parameters' => { 'notify' => 'Service[foo]' } },
-        { 'parameters' => { 'notify' => ['Service[foo]', 'Service[bar]'] } }
+        "File\ffoobar.json\fparameters\fnotify",
+        'Service[foo]',
+        ['Service[foo]', 'Service[bar]']
       ]
       diff_obj = OctocatalogDiff::API::V1::Diff.new(diff)
       result = subject.filtered?(diff_obj)

--- a/spec/octocatalog-diff/tests/catalog-diff/filter/single_item_array_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-diff/filter/single_item_array_spec.rb
@@ -34,7 +34,7 @@ describe OctocatalogDiff::CatalogDiff::Filter::SingleItemArray do
       expect(result).to eq(true)
     end
 
-    it 'should filter when from-catalog has string and to-catalog has array with that string' do
+    it 'should filter when to-catalog has string and from-catalog has array with that string' do
       diff = [
         '~',
         "File\ffoobar.json",
@@ -44,6 +44,30 @@ describe OctocatalogDiff::CatalogDiff::Filter::SingleItemArray do
       diff_obj = OctocatalogDiff::API::V1::Diff.new(diff)
       result = subject.filtered?(diff_obj)
       expect(result).to eq(true)
+    end
+
+    it 'should not filter when from-catalog has string and to-catalog has array with a different string' do
+      diff = [
+        '~',
+        "File\ffoobar.json",
+        { 'parameters' => { 'notify' => 'Service[bar]' } },
+        { 'parameters' => { 'notify' => ['Service[foo]'] } }
+      ]
+      diff_obj = OctocatalogDiff::API::V1::Diff.new(diff)
+      result = subject.filtered?(diff_obj)
+      expect(result).to eq(false)
+    end
+
+    it 'should not filter when to-catalog has string and from-catalog has array with a different string' do
+      diff = [
+        '~',
+        "File\ffoobar.json",
+        { 'parameters' => { 'notify' => ['Service[foo]'] } },
+        { 'parameters' => { 'notify' => 'Service[bar]' } }
+      ]
+      diff_obj = OctocatalogDiff::API::V1::Diff.new(diff)
+      result = subject.filtered?(diff_obj)
+      expect(result).to eq(false)
     end
   end
 end

--- a/spec/octocatalog-diff/tests/catalog-diff/filter/single_item_array_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-diff/filter/single_item_array_spec.rb
@@ -33,5 +33,17 @@ describe OctocatalogDiff::CatalogDiff::Filter::SingleItemArray do
       result = subject.filtered?(diff_obj)
       expect(result).to eq(true)
     end
+
+    it 'should filter when from-catalog has string and to-catalog has array with that string' do
+      diff = [
+        '~',
+        "File\ffoobar.json",
+        { 'parameters' => { 'notify' => ['Service[foo]'] } },
+        { 'parameters' => { 'notify' => 'Service[foo]' } }
+      ]
+      diff_obj = OctocatalogDiff::API::V1::Diff.new(diff)
+      result = subject.filtered?(diff_obj)
+      expect(result).to eq(true)
+    end
   end
 end

--- a/spec/octocatalog-diff/tests/catalog-diff/filter/single_item_array_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-diff/filter/single_item_array_spec.rb
@@ -69,5 +69,55 @@ describe OctocatalogDiff::CatalogDiff::Filter::SingleItemArray do
       result = subject.filtered?(diff_obj)
       expect(result).to eq(false)
     end
+
+    it 'should not filter when both of the items are arrays' do
+      diff = [
+        '~',
+        "File\ffoobar.json",
+        { 'parameters' => { 'notify' => ['Service[bar]'] } },
+        { 'parameters' => { 'notify' => ['Service[foo]'] } }
+      ]
+      diff_obj = OctocatalogDiff::API::V1::Diff.new(diff)
+      result = subject.filtered?(diff_obj)
+      expect(result).to eq(false)
+    end
+
+    it 'should not filter when both of the items are arrays even if identical' do
+      # This diff should never be produced by the program, but catch the edge case anyway.
+      diff = [
+        '~',
+        "File\ffoobar.json",
+        { 'parameters' => { 'notify' => ['Service[foo]'] } },
+        { 'parameters' => { 'notify' => ['Service[foo]'] } }
+      ]
+      diff_obj = OctocatalogDiff::API::V1::Diff.new(diff)
+      result = subject.filtered?(diff_obj)
+      expect(result).to eq(false)
+    end
+
+    it 'should not filter when both of the items are strings even if identical' do
+      # This diff should never be produced by the program, but catch the edge case anyway.
+      diff = [
+        '~',
+        "File\ffoobar.json",
+        { 'parameters' => { 'notify' => 'Service[foo]' } },
+        { 'parameters' => { 'notify' => 'Service[foo]' } }
+      ]
+      diff_obj = OctocatalogDiff::API::V1::Diff.new(diff)
+      result = subject.filtered?(diff_obj)
+      expect(result).to eq(false)
+    end
+
+    it 'should not filter when one item has an array with multiple elements' do
+      diff = [
+        '~',
+        "File\ffoobar.json",
+        { 'parameters' => { 'notify' => 'Service[foo]' } },
+        { 'parameters' => { 'notify' => ['Service[foo]', 'Service[bar]'] } }
+      ]
+      diff_obj = OctocatalogDiff::API::V1::Diff.new(diff)
+      result = subject.filtered?(diff_obj)
+      expect(result).to eq(false)
+    end
   end
 end


### PR DESCRIPTION
## Overview

This pull request adds a filter to treat an object the same as a single array containing that object. This difference can appear between some versions of Puppet but it really doesn't reflect an actual difference.

With filter off, this is a difference:

```
old: { notify: "Service[foo]" }
new: { notify: [ "Service[foo]" ] }
```

With the filter turned on, the above example is not a difference.

Fixes https://github.com/github/octocatalog-diff/issues/166

## Checklist

- [ ] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [ ] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [ ] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended.
