### PR TITLE
Require that all options have a specified weight

### DIFF
--- a/lib/octocatalog-diff/cli/options.rb
+++ b/lib/octocatalog-diff/cli/options.rb
@@ -23,7 +23,6 @@ module OctocatalogDiff
 
       # Define the Option class and newoption() method for use by cli/options/*.rb files
       class Option
-        DEFAULT_WEIGHT = 999
         def self.has_weight(w) # rubocop:disable Style/PredicateName
           @weight = w
         end
@@ -38,7 +37,9 @@ module OctocatalogDiff
           elsif @weight
             @weight
           else
-            DEFAULT_WEIGHT
+            # :nocov:
+            raise ArgumentError, "Option #{name} does not have a weight specified. Add 'has_weight NNN' to control ordering."
+            # :nocov:
           end
         end
 


### PR DESCRIPTION
## Overview

This pull request requires that all command line options have a "weight" to control their order.

This showed up as an incomplete test coverage result, that no options were using the "default weight". That's great, meaning all options have a specified weight. That's what we want, so this PR replaces the "default weight" code with an error message, to provide early warning if someone adds an option and doesn't supply a weight.

## Checklist

- [x] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [x] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
