### PR TITLE
Enhance CompilationDir to filter out cases outlined in #187 & #188

### DIFF
--- a/doc/dev/api/v1/objects/diff.md
+++ b/doc/dev/api/v1/objects/diff.md
@@ -94,9 +94,9 @@ Returns the value of the resource from the new catalog.
     }
   }
 
-  # Demonstrates structure and old_value
+  # Demonstrates structure and new_value
   diff.structure #=> ['parameters', 'content']
-  diff.old_value #=> 'This is the NEW FILE!!!!!'
+  diff.new_value #=> 'This is the NEW FILE!!!!!'
   ```
 
 #### `#old_file` (String)
@@ -107,7 +107,7 @@ Note that this is a pass-through of information provided in the Puppet catalog, 
 
 Note also that if the diff represents addition of a resource, this will return `nil`, because the resource does not exist in the old catalog.
 
-#### `#old_file` (String)
+#### `#old_line` (String)
 
 Returns the line number within the Puppet manifest giving rise to the resource as it exists in the old catalog. (See `#old_file` for the filename of the Puppet manifest.)
 

--- a/script/git-pre-commit
+++ b/script/git-pre-commit
@@ -4,8 +4,10 @@
 # base directory is up two levels, not just one.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd ../.. && pwd )"
 
+cd "$DIR"
+
 # Make sure we can use git correctly
-cd "$DIR" && git rev-parse --verify HEAD >/dev/null 2>&1
+git rev-parse --verify HEAD >/dev/null 2>&1
 if [ $? -ne 0 ]; then
   echo "Unable to determine revision of this git repo"
   exit 1

--- a/spec/octocatalog-diff/fixtures/catalogs/compilation-dir-1.json
+++ b/spec/octocatalog-diff/fixtures/catalogs/compilation-dir-1.json
@@ -53,6 +53,23 @@
         "parameters": {
           "dir": "/path/to/catalog1/onetime"
         }
+      },
+      {
+        "type": "Varies_Due_To_Compilation_Dir_5",
+        "title": "Common Title",
+        "tags": [
+          "ignoreme"
+        ],
+        "exported": false,
+        "parameters": {
+          "dir": {
+            "component": [
+              "path",
+              "/path/to/catalog1/twotimes",
+              "otherpath"
+            ]
+          }
+        }
       }
     ],
     "classes": [

--- a/spec/octocatalog-diff/fixtures/catalogs/compilation-dir-2.json
+++ b/spec/octocatalog-diff/fixtures/catalogs/compilation-dir-2.json
@@ -53,6 +53,19 @@
         "parameters": {
           "dir": "/path/to/catalog2/twotimes"
         }
+      },
+      {
+        "type": "Varies_Due_To_Compilation_Dir_5",
+        "title": "Common Title",
+        "tags": [
+          "ignoreme"
+        ],
+        "exported": false,
+        "parameters": {
+          "dir": {
+            "component": [ "path", "/path/to/catalog2/twotimes", "otherpath" ]
+          }
+        }
       }
     ],
     "classes": [


### PR DESCRIPTION
We were having some compilation dir differences in our catalog diff because of several use cases that weren't covered by the current `CompilationDir`.

This change implements a different way of checking for the compilation dir so that `CompilationDir` supports complex parameter values (ie nested hashes/arrays) and/or strings containing the compilation dir more than once.

To be noted that the chosen implementation might be much slower than the original algorithm because it defensively dups the parameter values. This might be problematic, and I'm open to suggestion on how to better implement this feature.

As a bonus I'm including a small minor fix of the API documentation of the diff object :)