### PR TITLE
Allow `--hostname` to receive a comma separated list of hosts and work on them in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@
 language: ruby
 install: true
 script: "script/cibuild"
-before_install: gem install bundler
 
 matrix:
   include:

--- a/doc/optionsref.md
+++ b/doc/optionsref.md
@@ -9,7 +9,8 @@
 
 ```
 Usage: octocatalog-diff [command line options]
-    -n, --hostname HOSTNAME          Use PuppetDB facts from last run of hostname
+    -n HOSTNAME1[,HOSTNAME2[,...]],  Use PuppetDB facts from last run of a hostname or a comma separated list of multiple hostnames
+        --hostname
         --basedir DIRNAME            Use an alternate base directory (git checkout of puppet repository)
     -f, --from FROM_BRANCH           Branch you are coming from
     -t, --to TO_BRANCH               Branch you are going to
@@ -856,14 +857,17 @@ Puppet control repo template, the value of this should be 'hieradata', which is 
 
   <tr>
     <td valign=top>
-      <pre><code>-n HOSTNAME
---hostname HOSTNAME</code></pre>
+      <pre><code>-n HOSTNAME1[,HOSTNAME2[,...]]
+--hostname HOSTNAME1[,HOSTNAME2[,...]]</code></pre>
     </td>
     <td valign=top>
-      Use PuppetDB facts from last run of hostname
+      Use PuppetDB facts from last run of a hostname or a comma separated list of multiple hostnames
     </td>
     <td valign=top>
-      Set hostname, which is used to look up facts in PuppetDB, and in the header of diff display. (<a href="../lib/octocatalog-diff/cli/options/hostname.rb">hostname.rb</a>)
+      Set hostname, which is used to look up facts in PuppetDB, and in the header of diff display.
+This option can recieve a single hostname, or a comma separated list of
+multiple hostnames, which are split into an Array. Multiple hostnames do not
+work with the `catalog-only` or `bootstrap-then-exit` options. (<a href="../lib/octocatalog-diff/cli/options/hostname.rb">hostname.rb</a>)
     </td>
   </tr>
 

--- a/lib/octocatalog-diff/cli/options.rb
+++ b/lib/octocatalog-diff/cli/options.rb
@@ -11,7 +11,7 @@ module OctocatalogDiff
     # This class contains the option parser. 'parse_options' is the external entry point.
     class Options
       # The usage banner.
-      BANNER = 'Usage: catalog-diff -n <hostname> [-f <from environment>] [-t <to environment>]'.freeze
+      BANNER = 'Usage: catalog-diff -n <hostname>[,<hostname>...] [-f <from environment>] [-t <to environment>]'.freeze
 
       # An error class specifically for passing information to the document build task.
       class DocBuildError < RuntimeError; end

--- a/lib/octocatalog-diff/cli/options/hostname.rb
+++ b/lib/octocatalog-diff/cli/options/hostname.rb
@@ -9,7 +9,7 @@ OctocatalogDiff::Cli::Options::Option.newoption(:hostname) do
 
   def parse(parser, options)
     parser.on('--hostname HOSTNAME', '-n', 'Use PuppetDB facts from last run of hostname') do |hostname|
-      options[:node] = hostname
+      options[:node] = hostname.split(',')
     end
   end
 end

--- a/lib/octocatalog-diff/cli/options/hostname.rb
+++ b/lib/octocatalog-diff/cli/options/hostname.rb
@@ -9,7 +9,11 @@ OctocatalogDiff::Cli::Options::Option.newoption(:hostname) do
 
   def parse(parser, options)
     parser.on('--hostname HOSTNAME', '-n', 'Use PuppetDB facts from last run of hostname') do |hostname|
-      options[:node] = hostname.split(',')
+      options[:node] = if hostname.include?(',')
+        hostname.split(',')
+      else
+        hostname
+      end
     end
   end
 end

--- a/lib/octocatalog-diff/cli/options/hostname.rb
+++ b/lib/octocatalog-diff/cli/options/hostname.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 # Set hostname, which is used to look up facts in PuppetDB, and in the header of diff display.
+# This option can recieve a single hostname, or a comma separated list of
+# multiple hostnames, which are split into an Array. Multiple hostnames do not
+# work with the `catalog-only` or `bootstrap-then-exit` options.
 # @param parser [OptionParser object] The OptionParser argument
 # @param options [Hash] Options hash being constructed; this is modified in this method.
 
@@ -8,7 +11,11 @@ OctocatalogDiff::Cli::Options::Option.newoption(:hostname) do
   has_weight 1
 
   def parse(parser, options)
-    parser.on('--hostname HOSTNAME', '-n', 'Use PuppetDB facts from last run of hostname') do |hostname|
+    parser.on(
+      '--hostname HOSTNAME1[,HOSTNAME2[,...]]',
+      '-n',
+      'Use PuppetDB facts from last run of a hostname or a comma separated list of multiple hostnames'
+    ) do |hostname|
       options[:node] = if hostname.include?(',')
         hostname.split(',')
       else

--- a/octocatalog-diff.gemspec
+++ b/octocatalog-diff.gemspec
@@ -27,6 +27,7 @@ EOF
   s.add_runtime_dependency 'diffy', '>= 3.1.0'
   s.add_runtime_dependency 'httparty', '>= 0.11.0'
   s.add_runtime_dependency 'hashdiff', '>= 0.3.0'
+  s.add_runtime_dependency 'parallel', '>= 1.12.0'
   s.add_runtime_dependency 'rugged', '>= 0.25.0b2'
 
   s.add_development_dependency 'rspec', '~> 3.4.0'

--- a/spec/octocatalog-diff/tests/cli/options/hostname_spec.rb
+++ b/spec/octocatalog-diff/tests/cli/options/hostname_spec.rb
@@ -6,7 +6,12 @@ describe OctocatalogDiff::Cli::Options do
   describe '#opt_hostname' do
     it 'should set options[:node] when hostname is set with short form' do
       result = run_optparse(['-n', 'octonode.rspec'])
-      expect(result.fetch(:node, 'key-not-defined')).to eq('octonode.rspec')
+      expect(result.fetch(:node, 'key-not-defined')).to eq(%w[octonode.rspec])
+    end
+
+    it 'should set multiple nodes when passed a series of nodes' do
+      result = run_optparse(['-n', 'octonode1.rspec,octonode2.rspec'])
+      expect(result.fetch(:node, 'key-not-defined')).to eq(%w[octonode1.rspec octonode2.rspec])
     end
   end
 end

--- a/spec/octocatalog-diff/tests/cli/options/hostname_spec.rb
+++ b/spec/octocatalog-diff/tests/cli/options/hostname_spec.rb
@@ -6,7 +6,7 @@ describe OctocatalogDiff::Cli::Options do
   describe '#opt_hostname' do
     it 'should set options[:node] when hostname is set with short form' do
       result = run_optparse(['-n', 'octonode.rspec'])
-      expect(result.fetch(:node, 'key-not-defined')).to eq(%w[octonode.rspec])
+      expect(result.fetch(:node, 'key-not-defined')).to eq('octonode.rspec')
     end
 
     it 'should set multiple nodes when passed a series of nodes' do


### PR DESCRIPTION
<!--
Hi there! We are delighted that you have chosen to contribute to octocatalog-diff.

If you have not already done so, please read our Contributing document, found here: https://github.com/github/octocatalog-diff/blob/master/.github/CONTRIBUTING.md

Please remember that all activity in this project, including pull requests, needs to comply with the Open Code of Conduct, found here: http://todogroup.org/opencodeofconduct/

Any contributions to this project must be made under the MIT license.

You do NOT need to bump the version number or regenerate the "Command line options reference" page. We will do this for you at or after the time we merge your contribution.
-->

## Overview

This pull request changes the hostname option to accept a string of multiple, comma separated hosts to diff and runs the diffs in parallel.

This changeset allows for octocatalog-diff to run against multiple hosts without having to resort to using some sort of loop (e.g. bash for loop) to iterate against the hosts.  My team currently uses octocatalog-diff in a CI setup to verify changes against multiple hosts before pushing up changes to our production branch, and it is currently both slow and somewhat inelegant to implement.  
These changes allow users to set up a CI system to run against many hosts to get a better picture of how changes might affect the overall environment by adding multiple hosts to the `-n` or `--hostname` option in a comma separated list, e.g.
```bash
octocatalog-diff -n example1.github.com,example2.github.com,webserver3.github.com
```

This also uses the `parallel` gem to do the diffing in parallel to greatly speed up the operation from either using shell loops or simply using ruby iteration (i.e. `nodes.each do`).  By my calculations (using the Unix `time` utility and running against two hosts), this results in a speedup of 2x:

```
[with parallel]
octocatalog-diff -n host1,host2  41.62s user 21.10s system 77% cpu 1:21.36 total

[iterating normally]
octocatalog-diff -n host1,host2  39.89s user 19.17s system 40% cpu 2:26.36 total

[shell iteration on single hosts]
( for host in host1 host2; do;  -n )  41.14s user 20.10s system 41% cpu 2:29.29 total
```

## Checklist

- [x] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [x] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [ ] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended.
- [x] If you have added any new gem dependencies, make sure those gems are licensed under the MIT or Apache 2.0 license. We cannot add any dependencies on gems licensed under GPL.
- [x] If you have added any new gem dependencies, make sure you've checked in a copy of the `.gem` file into the [vendor/cache](https://github.com/github/octocatalog-diff/tree/master/vendor/cache) directory.

/cc [related issues] [teams and individuals, making sure to mention why you're CC-ing them]
