### PR TITLE
Add 'name' parameter to the 'resource_hash' for validate_references

### DIFF
--- a/lib/octocatalog-diff/catalog.rb
+++ b/lib/octocatalog-diff/catalog.rb
@@ -331,8 +331,9 @@ module OctocatalogDiff
         title = normalized_title(resource['title'], resource['type'])
         @resource_hash[resource['type']][title] = resource
 
-        if resource.key?('parameters') && resource['parameters'].key?('alias')
-          @resource_hash[resource['type']][resource['parameters']['alias']] = resource
+        if resource.key?('parameters')
+          @resource_hash[resource['type']][resource['parameters']['alias']] = resource if resource['parameters'].key?('alias')
+          @resource_hash[resource['type']][resource['parameters']['name']] = resource if resource['parameters'].key?('name')
         end
       end
     end


### PR DESCRIPTION
## Overview

This pull request changes the `Catalog validation` functionality.

The `Apache` httpd server is well known to be THE software that has different names between RHEL based OS (`httpd`) and Debian + others ones (`apache2`).

For this kind of issue, Puppet allows you to add an `alias` parameter on any resource and this works fine in `octocatalog-diff`.

The Apache module we use (`puppetlabs-apache`,  "version": "2.3.0") defines the `name` parameter and not the `alias`. Then the catalog validation fails in our case (`puppetlabs-apache` + `voxpupuli/puppet-puppetboard:4.0.0`)

To work around this limitation, I added the `name` parameter to the `resources_hash` object if it exists.

## Checklist

- [x] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [x] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.

/cc [related issues] [teams and individuals, making sure to mention why you're CC-ing them]
