### PR TITLE
Add glob support for modulepath

### DIFF
--- a/lib/octocatalog-diff/catalog-util/fileresources.rb
+++ b/lib/octocatalog-diff/catalog-util/fileresources.rb
@@ -59,7 +59,7 @@ module OctocatalogDiff
           result = []
           Regexp.last_match(1).split(/:/).map(&:strip).each do |path|
             next if path.start_with?('$')
-            result << File.expand_path(path, dir)
+            result.concat(Dir.glob(File.expand_path(path, dir)))
           end
           result
         else

--- a/spec/octocatalog-diff/tests/catalog-util/fileresources_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-util/fileresources_spec.rb
@@ -83,8 +83,21 @@ describe OctocatalogDiff::CatalogUtil::FileResources do
     it 'should return proper entries from environment.conf modulepath' do
       allow(File).to receive(:file?).with('/a/environment.conf').and_return(true)
       allow(File).to receive(:read).with('/a/environment.conf').and_return('modulepath=modules:site:$basemoduledir')
+      allow(Dir).to receive(:glob).with('/a/modules').and_return(['/a/modules'])
+      allow(Dir).to receive(:glob).with('/a/site').and_return(['/a/site'])
       result = OctocatalogDiff::CatalogUtil::FileResources.module_path('/a')
       expect(result).to eq(['/a/modules', '/a/site'])
+    end
+
+    it 'should expand globs in modulepath, if present' do
+      allow(File).to receive(:file?).with('/a/environment.conf').and_return(true)
+      allow(File).to receive(:read).with('/a/environment.conf')
+        .and_return('modulepath=modules:extra_mods/*/modules:$basemoduledir')
+      allow(Dir).to receive(:glob).with('/a/modules').and_return(['/a/modules'])
+      allow(Dir).to receive(:glob).with('/a/extra_mods/*/modules')
+        .and_return(['/a/extra_mods/a/modules', '/a/extra_mods/b/modules'])
+      result = OctocatalogDiff::CatalogUtil::FileResources.module_path('/a')
+      expect(result).to eq(['/a/modules', '/a/extra_mods/a/modules', '/a/extra_mods/b/modules'])
     end
   end
 


### PR DESCRIPTION
Recent versions of Puppet support glob expansion in the environment specified modulepath. This change is required for environments which take advantage of this support.
