### PR TITLE
Fix broken link to roadmap in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,7 +22,7 @@ We will handle updating the version, tagging the release, and releasing the gem.
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:
 
-- Make sure your contribution is consistent with our [roadmap](roadmap.md).
+- Make sure your contribution is consistent with our [roadmap](/doc/roadmap.md).
 
 - Follow the [style guide](https://github.com/bbatsov/ruby-style-guide).
 


### PR DESCRIPTION
<!--
Hi there! We are delighted that you have chosen to contribute to octocatalog-diff.

If you have not already done so, please read our Contributing document, found here: https://github.com/github/octocatalog-diff/blob/master/.github/CONTRIBUTING.md

Please remember that all activity in this project, including pull requests, needs to comply with the Open Code of Conduct, found here: http://todogroup.org/opencodeofconduct/

Any contributions to this project must be made under the MIT license.

You do NOT need to bump the version number or regenerate the "Command line options reference" page. We will do this for you at or after the time we merge your contribution.
-->

This pull request changes a reference to roadmap.md in CONTRIBUTING.md. The first reference to it in the contributers guide is correct, I think the `/doc` prefix was just accidentally left out.

Please let me know if you see any problems with this/other things to improve.