### PR TITLE
Update documentation link

### DIFF
--- a/lib/octocatalog-diff/external/pson/README.md
+++ b/lib/octocatalog-diff/external/pson/README.md
@@ -3,8 +3,8 @@
 Puppet uses a JSON variant called PSON to serialize data (e.g. facts) transmitting to/from a Puppet master.
 
 Documentation for PSON can be found here:
-
-    https://docs.puppet.com/puppet/4.6/reference/http_api/pson.html
+ 
+    https://puppet.com/docs/puppet/latest/http_api/pson.html
 
 The code in this directory was taken directly from Puppet and can be found at:
 


### PR DESCRIPTION
## Overview

The documentation format has changed. I think I found the most relevant link and modified it so it's latest rather than a specific version. It might be something that needs to be tied to a specific version tho.

Didn't do any tests/CI/integration tests/dependencies as this is doc update.

## Checklist

- [ ] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [ ] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [ ] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended.
- [ ] If you have added any new gem dependencies, make sure those gems are licensed under the MIT or Apache 2.0 license. We cannot add any dependencies on gems licensed under GPL.
- [ ] If you have added any new gem dependencies, make sure you've checked in a copy of the `.gem` file into the [vendor/cache](https://github.com/github/octocatalog-diff/tree/master/vendor/cache) directory.

