### PR TITLE
Add Support for Hashdiff 1.0.0

### DIFF
--- a/lib/octocatalog-diff/catalog-diff/differ.rb
+++ b/lib/octocatalog-diff/catalog-diff/differ.rb
@@ -11,6 +11,8 @@ require_relative '../errors'
 require_relative '../util/util'
 require_relative 'filter'
 
+HashDiff = Hashdiff unless defined? HashDiff
+
 module OctocatalogDiff
   module CatalogDiff
     # Calculate the difference between two Puppet catalogs.


### PR DESCRIPTION
## Overview

This pull request introduces support for Hashdiff version 1.0.0.

When using Hashdiff version 1.0.0, octocatalog-diff failed with the following error:
`uninitialized constant OctocatalogDiff::CatalogDiff::Differ::HashDiff (NameError)`.

See also: https://github.com/liufengyun/hashdiff/issues/45

Hashdiff 1.0.0 was released on July, 15 2019 and replaced the constant "HashDiff" with "Hashdiff".

This commit fixes this error and keeps octocatalog-diff backwards compatible to older versions
of HashDiff.

## Checklist

- [x] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [X] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [X] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended.
- [X] If you have added any new gem dependencies, make sure those gems are licensed under the MIT or Apache 2.0 license. We cannot add any dependencies on gems licensed under GPL.
- [X] If you have added any new gem dependencies, make sure you've checked in a copy of the `.gem` file into the [vendor/cache](https://github.com/github/octocatalog-diff/tree/master/vendor/cache) directory.