### PR TITLE
Hide sensitive parameters

### DIFF
--- a/lib/octocatalog-diff/catalog-diff/differ.rb
+++ b/lib/octocatalog-diff/catalog-diff/differ.rb
@@ -465,7 +465,7 @@ module OctocatalogDiff
         # hides sensitive params. We still need to know if there's a going to
         # be a diff, so we hash the value.
         sensitive_parameters.each do |p|
-          md5 = Digest::MD5.hexdigest result[p]
+          md5 = Digest::MD5.hexdigest Marshal.dump(result[p])
           result[p] = 'Sensitive [md5sum ' + md5 + ']'
         end
 

--- a/lib/octocatalog-diff/catalog-diff/differ.rb
+++ b/lib/octocatalog-diff/catalog-diff/differ.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'diffy'
+require 'digest'
 require 'hashdiff'
 require 'json'
 require 'set'
@@ -263,7 +264,7 @@ module OctocatalogDiff
 
             # Handle parameters
             if k == 'parameters'
-              cleansed_param = cleanse_parameters_hash(v)
+              cleansed_param = cleanse_parameters_hash(v, resource.fetch('sensitive_parameters', []))
               hsh[k] = cleansed_param unless cleansed_param.nil? || cleansed_param.empty?
             elsif k == 'tags'
               # The order of tags is unimportant. Sort this array to avoid false diffs if order changes.
@@ -456,9 +457,17 @@ module OctocatalogDiff
 
       # Cleanse parameters of filtered attributes.
       # @param parameters_hash [Hash] Hash of parameters
+      # @param sensitive_parameters [Array] Array of sensitive parameters
       # @return [Hash] Cleaned parameters hash (original input hash is not altered)
-      def cleanse_parameters_hash(parameters_hash)
+      def cleanse_parameters_hash(parameters_hash, sensitive_parameters)
         result = parameters_hash.dup
+
+        # hides sensitive params. We still need to know if there's a going to
+        # be a diff, so we hash the value.
+        sensitive_parameters.each do |p|
+          md5 = Digest::MD5.hexdigest result[p]
+          result[p] = 'Sensitive [md5sum ' + md5 + ']'
+        end
 
         # 'before' and 'require' handle internal Puppet ordering but do not affect what
         # happens on the target machine. Don't consider these for the purpose of catalog diff.

--- a/spec/octocatalog-diff/tests/catalog-diff/differ_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-diff/differ_spec.rb
@@ -382,6 +382,30 @@ describe OctocatalogDiff::CatalogDiff::Differ do
           result = testobj.catalog1
           expect(result.first['title']).to eq('/etc/foo')
         end
+
+        it 'should hide sensitive parameters' do
+          json_hash = {
+            'document_type' => 'Catalog',
+            'data' => {
+              'name' => 'rspec-node.github.net',
+              'tags' => [],
+              'resources' => [
+                {
+                  'type' => 'File',
+                  'title' => 'verysecretfile',
+                  'parameters' => {
+                    'content' => 'secret1'
+                  },
+                  'sensitive_parameters' => ['content']
+                }
+              ]
+            }
+          }
+          catalog = OctocatalogDiff::Catalog.create(json: JSON.generate(json_hash))
+          testobj = OctocatalogDiff::CatalogDiff::Differ.new(@options, catalog, @empty_puppet_catalog)
+          result = testobj.catalog1
+          expect(result.first['parameters']['content']).to eq('Sensitive [md5sum e52d98c459819a11775936d8dfbb7929]')
+        end
       end
 
       describe '#diff' do


### PR DESCRIPTION
<!--
Hi there! We are delighted that you have chosen to contribute to octocatalog-diff.

If you have not already done so, please read our Contributing document, found here: https://github.com/github/octocatalog-diff/blob/master/.github/CONTRIBUTING.md

Please remember that all activity in this project, including pull requests, needs to comply with the Open Code of Conduct, found here: http://todogroup.org/opencodeofconduct/

Any contributions to this project must be made under the MIT license.

You do NOT need to bump the version number or regenerate the "Command line options reference" page. We will do this for you at or after the time we merge your contribution.
-->

## Overview

This pull request introduces hiding of Sensitive data output.

Puppet now has type Sensitive, which hides the content from logs, etc. Hide it similarly in output of octocatalog-diff, by using a trivial hash so that any diff will still be show.

See also: https://puppet.com/docs/puppet/5.3/lang_data_sensitive.html
## Checklist

- [x] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [x] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [x] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended.
- [x] If you have added any new gem dependencies, make sure those gems are licensed under the MIT or Apache 2.0 license. We cannot add any dependencies on gems licensed under GPL.
- [x] If you have added any new gem dependencies, make sure you've checked in a copy of the `.gem` file into the [vendor/cache](https://github.com/github/octocatalog-diff/tree/master/vendor/cache) directory.