### PR TITLE
(#223) display diff for nested arrays of objects

### DIFF
--- a/lib/octocatalog-diff/catalog-diff/differ.rb
+++ b/lib/octocatalog-diff/catalog-diff/differ.rb
@@ -622,9 +622,14 @@ module OctocatalogDiff
       def dig_out_key(hash_in, key_array)
         return hash_in if key_array.empty?
         return hash_in unless hash_in.is_a?(Hash)
-        return nil unless hash_in.key?(key_array[0])
-        next_key = key_array.shift
-        dig_out_key(hash_in[next_key], key_array)
+        key_without_index = key_array[0].sub(/\[\d+\]/, '')
+        return nil unless hash_in.key?(key_without_index)
+        full_key = key_array.shift
+        next_obj = hash_in[key_without_index]
+        # jump into array index if needed
+        md = full_key.match(/\[(\d+)\]/)
+        next_obj = next_obj[md[1].to_i] if md
+        dig_out_key(next_obj, key_array)
       end
 
       # This is a helper for the constructor, verifying that the incoming catalog is an expected


### PR DESCRIPTION
<!--
Hi there! We are delighted that you have chosen to contribute to octocatalog-diff.

If you have not already done so, please read our Contributing document, found here: https://github.com/github/octocatalog-diff/blob/master/.github/CONTRIBUTING.md

Please remember that all activity in this project, including pull requests, needs to comply with the Open Code of Conduct, found here: http://todogroup.org/opencodeofconduct/

Any contributions to this project must be made under the MIT license.

You do NOT need to bump the version number or regenerate the "Command line options reference" page. We will do this for you at or after the time we merge your contribution.
-->

## Overview

This pull request fixes #223. 

When using octocatalog-diff with puppet resources with deep nested datastructures such as nested arrays of objects, octocatalog-diff would not display diffs when array elements are modified, added or removed.

In fact, it turns out `dig_out_key` doesn't descend into arrays index that hashdiff can produce, like for instance: 
`testtype::test::parameters::testparam::another-one::an-array[0]::env`

`dig_out_key` would stop at `an-array` because it doesn't know that's and array index it should try to descend into.

This patch adds the functionality for `dig_out_key` to follow array indices and descend into those nested structures.

## Checklist

- [x] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [x] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [ ] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended.
- [ ] If you have added any new gem dependencies, make sure those gems are licensed under the MIT or Apache 2.0 license. We cannot add any dependencies on gems licensed under GPL.
- [ ] If you have added any new gem dependencies, make sure you've checked in a copy of the `.gem` file into the [vendor/cache](https://github.com/github/octocatalog-diff/tree/master/vendor/cache) directory.

/cc #223