### PR TITLE
Add support for Puppet 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
     # Build with latest ruby
     - rvm: 2.5
       env: RUBOCOP_TEST="false" RSPEC_TEST="true" PUPPET_VERSIONS="5.5.8"
+    - rvm: 2.5
+      env: RUBOCOP_TEST="true" RSPEC_TEST="true" PUPPET_VERSIONS="6.18.0"
     # Puppet supports ruby 2.0 and 2.1 with Puppet 4.x, but build with more recent versions too
     - rvm: 2.3
       env: RUBOCOP_TEST="false" RSPEC_TEST="true" PUPPET_VERSIONS="4.10.10"

--- a/lib/octocatalog-diff/catalog-util/command.rb
+++ b/lib/octocatalog-diff/catalog-util/command.rb
@@ -22,6 +22,8 @@ module OctocatalogDiff
         @node = options[:node]
         raise ArgumentError, 'Node must be specified to compile catalog' if @node.nil? || !@node.is_a?(String)
 
+        @puppet_version = options[:puppet_version]
+
         # To be initialized on-demand
         @puppet_argv = nil
         @puppet_binary = nil
@@ -56,7 +58,12 @@ module OctocatalogDiff
 
         # Node to compile
         cmdline = []
-        cmdline.concat ['master', '--compile', Shellwords.escape(@node)]
+
+        if Gem::Version.new(@puppet_version) >= Gem::Version.new('6.0.0')
+          cmdline.concat ['catalog', 'compile', Shellwords.escape(@node)]
+        else
+          cmdline.concat ['master', '--compile', Shellwords.escape(@node)]
+        end
 
         # storeconfigs?
         if @options[:storeconfigs]
@@ -95,7 +102,7 @@ module OctocatalogDiff
           --no-daemonize
           --no-ca
           --color=false
-          --config_version="/bin/echo catalogscript"
+          --config_version="/usr/bin/true"
         )
 
         # Add environment - only make this variable if preserve_environments is used.

--- a/lib/octocatalog-diff/catalog/computed.rb
+++ b/lib/octocatalog-diff/catalog/computed.rb
@@ -145,6 +145,7 @@ module OctocatalogDiff
             compilation_dir: @builddir.tempdir,
             parser: @options.fetch(:parser, :default),
             puppet_binary: @puppet_binary,
+            puppet_version: puppet_version,
             fact_file: @builddir.fact_file,
             dir: @builddir.tempdir,
             enc: @builddir.enc


### PR DESCRIPTION
<!--
Hi there! We are delighted that you have chosen to contribute to octocatalog-diff.

If you have not already done so, please read our Contributing document, found here: https://github.com/github/octocatalog-diff/blob/master/.github/CONTRIBUTING.md

Please remember that all activity in this project, including pull requests, needs to comply with the Open Code of Conduct, found here: http://todogroup.org/opencodeofconduct/

Any contributions to this project must be made under the MIT license.

You do NOT need to bump the version number or regenerate the "Command line options reference" page. We will do this for you at or after the time we merge your contribution.
-->

## Overview

This pull request introduces support for Puppet 6.

(Please write a summary of your pull request here. This paragraph should go into detail about what is changing, the motivation behind this change, and the approach you took.)

## Checklist

- [ ] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [ ] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [ ] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended.
- [ ] If you have added any new gem dependencies, make sure those gems are licensed under the MIT or Apache 2.0 license. We cannot add any dependencies on gems licensed under GPL.
- [ ] If you have added any new gem dependencies, make sure you've checked in a copy of the `.gem` file into the [vendor/cache](https://github.com/github/octocatalog-diff/tree/master/vendor/cache) directory.

/cc [related issues] [teams and individuals, making sure to mention why you're CC-ing them]
