### PR TITLE
Add set quality comparison to ignore filter

### DIFF
--- a/doc/advanced-ignores.md
+++ b/doc/advanced-ignores.md
@@ -222,3 +222,13 @@ File[/tmp/foo] =>
 In this case, the very important line was removed from the catalog, and you want to know about this. Ignoring `File[/tmp/foo]::parameters::content` would have suppressed this (because all changes to that attribute are ignored). Also ignoring `File[/tmp/foo]::parameters::content=~>This is the line in the new catalog that I do not care about$` would have also suppressed this (because the regular expression was matched for *one* of the lines). However, the two examples with `=&>` in this section would *not* have suppressed this change, because it is no longer the case that *all* changes in the file matched the regular expression.
 
 :warning: All lines are stripped of leading and trailing spaces before the regular expression match is tried. This stripping of whitespace is done *only* for this comparison stage, and does not affect the display of any results.
+
+#### Ignoring attributes which have identical elements but in arbitrary order
+
+You can ignore attributes where both the values in both the old and new catalogs are arrays and the arrays
+contain identical elements but in arbitrary order. Basically, you can ignore a parameter where the values
+have set equality.
+
+To ignore any parameters named `foo` with values having set equality, you would use:
+
+      --ignore 'My::Custom::Resource[*]::parameters::foo=s>='

--- a/lib/octocatalog-diff/catalog-diff/differ.rb
+++ b/lib/octocatalog-diff/catalog-diff/differ.rb
@@ -340,7 +340,8 @@ module OctocatalogDiff
         #   =->  Attribute must have been removed and equal this
         #   =~>  Change must match regexp (one line of change matching is sufficient)
         #   =&>  Change must match regexp (all lines of change MUST match regexp)
-        if rule_attr =~ /\A(.+?)(=[\-\+~&]?>)(.+)/m
+        #   =s>  Change must be array and contain identical elements, ignoring order
+        if rule_attr =~ /\A(.+?)(=[\-\+~&s]?>)(.+)/m
           rule_attr = Regexp.last_match(1)
           operator = Regexp.last_match(2)
           value = Regexp.last_match(3)
@@ -361,6 +362,9 @@ module OctocatalogDiff
               raise RegexpError, "Invalid ignore regexp for #{key}: #{exc.message}"
             end
             matcher = ->(x, y) { regexp_operator_match?(operator, my_regex, x, y) }
+          elsif operator == '=s>'
+            raise ArgumentError, "Invalid ignore option for =s>, must be '='" unless value == '='
+            matcher = ->(x, y) { x.is_a?(Array) && y.is_a?(Array) && Set.new(x) == Set.new(y) }
           end
         end
 

--- a/spec/octocatalog-diff/fixtures/catalogs/ignore-parameter-set-1.json
+++ b/spec/octocatalog-diff/fixtures/catalogs/ignore-parameter-set-1.json
@@ -1,0 +1,28 @@
+{
+  "document_type": "Catalog",
+  "data": {
+    "tags": ["settings"],
+    "name": "my.rspec.node",
+    "version": "production",
+    "environment": "production",
+    "resources": [
+      {
+        "type": "Myres",
+        "title": "res1",
+        "file": "/environments/production/modules/foo/manifests/init.pp",
+        "line": 10,
+        "exported": false,
+        "parameters": {
+          "set1": ["one", "two", "three"],
+          "set2": ["a", "b"]
+        }
+      }
+    ],
+    "classes": [
+      "settings"
+    ]
+  },
+  "metadata": {
+    "api_version": 1
+  }
+}

--- a/spec/octocatalog-diff/fixtures/catalogs/ignore-parameter-set-2.json
+++ b/spec/octocatalog-diff/fixtures/catalogs/ignore-parameter-set-2.json
@@ -1,0 +1,29 @@
+{
+  "document_type": "Catalog",
+  "data": {
+    "tags": ["settings"],
+    "name": "my.rspec.node",
+    "version": "production",
+    "environment": "production",
+    "resources": [
+      {
+        "type": "Myres",
+        "title": "res1",
+        "file": "/environments/production/modules/foo/manifests/init.pp",
+        "line": 10,
+        "exported": false,
+        "parameters": {
+          "set1": ["three", "two", "one"],
+          "set2": ["a", "b", "c"],
+          "set3": [1, 2, 3]
+        }
+      }
+    ],
+    "classes": [
+      "settings"
+    ]
+  },
+  "metadata": {
+    "api_version": 1
+  }
+}

--- a/spec/octocatalog-diff/tests/catalog-diff/differ_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-diff/differ_spec.rb
@@ -1234,6 +1234,73 @@ describe OctocatalogDiff::CatalogDiff::Differ do
     end
   end
 
+  context 'ignoring changes in sets' do
+    describe '#ignore' do
+      before(:all) do
+        @c1 = OctocatalogDiff::Catalog.create(json: OctocatalogDiff::Spec.fixture_read('catalogs/ignore-parameter-set-1.json'))
+        @c2 = OctocatalogDiff::Catalog.create(json: OctocatalogDiff::Spec.fixture_read('catalogs/ignore-parameter-set-2.json'))
+        @set1 = [
+          '!',
+          "Myres\fres1\fparameters\fset1",
+          %w(one two three),
+          %w(three two one)
+        ]
+        @set2 = [
+          '!',
+          "Myres\fres1\fparameters\fset2",
+          %w(a b),
+          %w(a b c)
+        ]
+        @set3 = [
+          '!',
+          "Myres\fres1\fparameters\fset3",
+          nil,
+          [1, 2, 3]
+        ]
+      end
+
+      it 'should not filter out a change when attribute does not match' do
+        opts = {}
+        testobj = OctocatalogDiff::CatalogDiff::Differ.new(opts, @c1, @c2)
+        testobj.ignore(type: 'Myres', title: 'res1', attr: "parameters\fmode")
+        result = testobj.diff
+        expect(OctocatalogDiff::Spec.array_contains_partial_array?(result, @set1)).to eq(true)
+        expect(OctocatalogDiff::Spec.array_contains_partial_array?(result, @set2)).to eq(true)
+        expect(OctocatalogDiff::Spec.array_contains_partial_array?(result, @set3)).to eq(true)
+      end
+
+      it 'should filter out a change when two arrays have set equality' do
+        opts = {}
+        testobj = OctocatalogDiff::CatalogDiff::Differ.new(opts, @c1, @c2)
+        testobj.ignore(type: 'Myres', title: 'res1', attr: "parameters\fset1=s>=")
+        result = testobj.diff
+        expect(OctocatalogDiff::Spec.array_contains_partial_array?(result, @set1)).to eq(false)
+        expect(OctocatalogDiff::Spec.array_contains_partial_array?(result, @set2)).to eq(true)
+        expect(OctocatalogDiff::Spec.array_contains_partial_array?(result, @set3)).to eq(true)
+      end
+
+      it 'should not filter out a change when two arrays are not equivalent sets' do
+        opts = {}
+        testobj = OctocatalogDiff::CatalogDiff::Differ.new(opts, @c1, @c2)
+        testobj.ignore(type: 'Myres', title: 'res1', attr: "parameters\fset2=s>=")
+        result = testobj.diff
+        expect(OctocatalogDiff::Spec.array_contains_partial_array?(result, @set1)).to eq(true)
+        expect(OctocatalogDiff::Spec.array_contains_partial_array?(result, @set2)).to eq(true)
+        expect(OctocatalogDiff::Spec.array_contains_partial_array?(result, @set3)).to eq(true)
+      end
+
+      it 'should not filter out a change when one array is not specified' do
+        opts = {}
+        testobj = OctocatalogDiff::CatalogDiff::Differ.new(opts, @c1, @c2)
+        testobj.ignore(type: 'Myres', title: 'res1', attr: "parameters\fset3=s>=")
+        result = testobj.diff
+        expect(OctocatalogDiff::Spec.array_contains_partial_array?(result, @set1)).to eq(true)
+        expect(OctocatalogDiff::Spec.array_contains_partial_array?(result, @set2)).to eq(true)
+        expect(OctocatalogDiff::Spec.array_contains_partial_array?(result, @set3)).to eq(true)
+      end
+    end
+  end
+
   describe '#ignore_match?' do
     let(:resource) { { type: 'Apple', title: 'delicious', attr: "parameters\fcolor" } }
     let(:testobj) { described_class.allocate }


### PR DESCRIPTION
## Overview

This pull request introduces new functionality to the `--ignore` option, allowing array values to parameters to be ignored if they have set equality.

Resources may accept array parameters but may not change behavior depending on the order of those parameters. In those situations it would be good to be able to ignore changes due only to array ordering.

## Checklist

- [x] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [x] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [x] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended.
- [x] If you have added any new gem dependencies, make sure those gems are licensed under the MIT or Apache 2.0 license. We cannot add any dependencies on gems licensed under GPL.
- [x] If you have added any new gem dependencies, make sure you've checked in a copy of the `.gem` file into the [vendor/cache](https://github.com/github/octocatalog-diff/tree/master/vendor/cache) directory.
