### PR TITLE
Handle JSON facts structured as name/values

### DIFF
--- a/lib/octocatalog-diff/facts/json.rb
+++ b/lib/octocatalog-diff/facts/json.rb
@@ -14,8 +14,19 @@ module OctocatalogDiff
       # @return [Hash] Facts
       def self.fact_retriever(options = {}, node = '')
         facts = ::JSON.parse(options.fetch(:fact_file_string))
-        node = facts.fetch('fqdn', 'unknown.node') if node.empty?
-        { 'name' => node, 'values' => facts }
+
+        if facts.keys.include?('name') && facts.keys.include?('values') && facts['values'].is_a?(Hash)
+          # If you saved the output of something like
+          # `puppet facts find $(hostname)` the structure will already be a
+          # {'name' => <fqdn>, 'values' => <hash of facts>}. We do nothing
+          # here because we don't want to double-encode.
+        else
+          facts = { 'name' => node, 'values' => facts }
+        end
+
+        facts['name'] = node unless node.empty?
+        facts['name'] = facts['values'].fetch('fqdn', 'unknown.node') if facts['name'].empty?
+        facts
       end
     end
   end

--- a/spec/octocatalog-diff/fixtures/facts/encoded-facts.json
+++ b/spec/octocatalog-diff/fixtures/facts/encoded-facts.json
@@ -1,0 +1,10 @@
+{
+  "name":"rspec-node.abc.github.net",
+  "values":{
+    "apt_update_last_success":1458162123,
+    "architecture":"amd64",
+    "datacenter":"xyz",
+    "fqdn":"rspec-node.xyz.github.net",
+    "_timestamp":"2014-12-02 14:56:20 -0600"
+  }
+}

--- a/spec/octocatalog-diff/tests/facts/json_spec.rb
+++ b/spec/octocatalog-diff/tests/facts/json_spec.rb
@@ -39,5 +39,30 @@ describe OctocatalogDiff::Facts::JSON do
       expect(result['name']).to eq('override.node')
       expect(result['values']['fqdn']).to eq('rspec-node.xyz.github.net')
     end
+
+    it 'should fill in a missing name from hash with name/values' do
+      fact_file = OctocatalogDiff::Spec.fixture_path('facts/encoded-facts.json')
+      data = JSON.parse(File.read(fact_file))
+      data['name'] = ''
+      options = {
+        fact_file_string: JSON.generate(data)
+      }
+      result = OctocatalogDiff::Facts::JSON.fact_retriever(options)
+      expect(result).to be_a_kind_of(Hash)
+      expect(result['name']).to eq('rspec-node.xyz.github.net')
+      expect(result['values']['fqdn']).to eq('rspec-node.xyz.github.net')
+    end
+
+    it 'should not double-encode hash already containing name and values' do
+      fact_file = OctocatalogDiff::Spec.fixture_path('facts/encoded-facts.json')
+      options = {
+        fact_file_string: File.read(fact_file)
+      }
+      result = OctocatalogDiff::Facts::JSON.fact_retriever(options)
+      expect(result).to be_a_kind_of(Hash)
+      expect(result.keys).to match_array(%w(name values))
+      expect(result['name']).to eq('rspec-node.abc.github.net')
+      expect(result['values']['fqdn']).to eq('rspec-node.xyz.github.net')
+    end
   end
 end


### PR DESCRIPTION

## Overview

This pull request allows JSON facts to come in the following format without double-encoding them. You can get facts structured like this by running `puppet facts find $(hostname)`:

```json
{
  "name":"rspec-node.abc.github.net",
  "values":{
    "apt_update_last_success":1458162123,
    "architecture":"amd64",
    "datacenter":"xyz",
    "fqdn":"rspec-node.xyz.github.net",
    "_timestamp":"2014-12-02 14:56:20 -0600"
  }
}
```

The YAML fact handler already had logic that dealt with this case, but the JSON handler didn't. So if you submitted the above JSON file in `--fact-file` it would end up double-encoding them internally:

```json
{
  "name":"unknown.node",
  "values":{
    "name": "rspec-node.abc.github.net",
    "values":{
      "apt_update_last_success":1458162123,
      "architecture":"amd64",
      "datacenter":"xyz",
      "fqdn":"rspec-node.xyz.github.net",
      "_timestamp":"2014-12-02 14:56:20 -0600"
    }
  }
}
```

## Checklist

- [x] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [x] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [ ] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended.
- [ ] If you have added any new gem dependencies, make sure those gems are licensed under the MIT or Apache 2.0 license. We cannot add any dependencies on gems licensed under GPL.
- [ ] If you have added any new gem dependencies, make sure you've checked in a copy of the `.gem` file into the [vendor/cache](https://github.com/github/octocatalog-diff/tree/master/vendor/cache) directory.