### PR TITLE
Update capability and docs of --compare-file-text

### DIFF
--- a/doc/advanced-compare-file-text.md
+++ b/doc/advanced-compare-file-text.md
@@ -1,0 +1,79 @@
+# Compare file text
+
+`octocatalog-diff` contains functionality to detect changes in file content for file resources that use the `source` attribute like this:
+
+```
+file { '/etc/logrotate.d/my-service.conf':
+  source => 'puppet:///modules/logrotate/etc/logrotate.d/my-service.conf',
+}
+```
+
+When the `source` attribute is used, the catalog contains the value of the attribute (in the example above, `source` = `puppet:///modules/logrotate/etc/logrotate.d/my-service.conf`). However, the catalog does not contain the content of the file. When an agent applies the catalog, the file found on the server or in the code base at `modules/logrotate/file/etc/logrotate.d/my-service.conf` will be installed into `/etc/logrotate.d/my-service.conf`.
+
+If a developer creates a change to this file, the catalog will not indicate this change. This means that so long as the `source` location does not change, any tool analyzing just the catalog would not detect a "diff" resulting from changes in the underlying file itself.
+
+However, since applying the catalog could change the content of a file on the target node, `octocatalog-diff` has a feature that will do the following for any `source => 'puppet:///modules/...'` files:
+
+- Locate the source file in the Puppet code
+- Substitute the content of the file into the generated catalog (remove `source` and populate `content`)
+- Display the "diff" in the now-populated `content` field
+
+This feature is available only when the catalogs are being compiled from local code. This feature is not available, and will be automatically disabled, when pulling catalogs from PuppetDB or a Puppet server.
+
+Note: In Puppet >= 4.4 there is an option in Puppet itself called "static catalogs" which if enabled will cause the checksum of the file to be included in the catalog. However, the `octocatalog-diff` feature described here is still useful because it can be used to display a "diff" of the change rather than just displaying a "diff" of a checksum.
+## Command line options
+
+### `--compare-file-text` and `--no-compare-file-text`
+
+The feature described above is enabled by default, and no special setup is required.
+
+To disable this feature for a specific run, add `--no-compare-file-text` to the command line.
+
+To disable this feature by default, add the following to a [configuration](/doc/configuration.md) file:
+
+```ruby
+settings[:compare_file_text] = false
+```
+
+If this feature is disabled by default in a configuration file, add `--compare-file-text` to enable the feature for this specific run.
+
+Note that the feature will be automatically disabled, regardless of configuration or command line options, if catalogs are being pulled from PuppetDB or a Puppet server.
+
+### `--compare-file-text-ignore-tags`
+
+To disable this feature for specific `file` resources, set a tag on the resources for which the comparison is undesired. For example:
+
+```
+file { '/etc/logrotate.d/my-service.conf':
+  source => 'puppet:///modules/logrotate/etc/logrotate.d/my-service.conf',
+}
+
+file { '/etc/logrotate.d/other-service.conf':
+  tag    => ['compare-file-text-disable'],
+  source => 'puppet:///modules/logrotate/etc/logrotate.d/other-service.conf',
+}
+```
+
+Inform `octocatalog-diff` of the name of the tag either via the command line (`--compare-file-text-ignore-tags "compare-file-text-disable"`) or via a [configuration](/doc/configuration.md) file:
+
+```ruby
+settings[:compare_file_text_ignore_tags] = %w(compare-file-text-disable)
+```
+
+With this example setup, the file text would be compared for `/etc/logrotate.d/my-service.conf` but would NOT be compared for `/etc/logrotate.d/other-service.conf`.
+
+Notes:
+
+1. `--compare-file-text-ignore-tags` can take comma-separated arguments if there are multiple tags, e.g.: `--compare-file-text-ignore-tags tag1,tag2`.
+
+1. When defining values in the configuration file, `settings[:compare_file_text_ignore_tags]` must be an array. (The default value is an empty array, `[]`.)
+
+1. "compare-file-text-disable" is used as the name of the tag in the example above, but it is not a magical value. Any valid tag name can be used.
+
+## Notes
+
+1. If the underlying file source cannot be found when building the "to" catalog, an exception will be raised. This will display the resource type and title, the value of `source` that is invalid, and the file name and line number of the Puppet manifest that declared the resource.
+
+1. If the underlying file source cannot be found when building the "from" catalog, no exception will be raised. This behavior allows `octocatalog-diff` to work correctly even if there is a problem in the "from" catalog that is being corrected in the "to" catalog. (Of course, if the underlying file source can't be found in the "to" catalog either, an exception is raised -- see #1.)
+
+1. No processing takes place for file `source` whose values do not start with `puppet:///modules/`.

--- a/doc/optionsref.md
+++ b/doc/optionsref.md
@@ -185,6 +185,8 @@ Usage: octocatalog-diff [command line options]
         --no-ignore-tags             Disable ignoring based on tags
         --ignore-tags STRING1[,STRING2[,...]]
                                      Specify tags to ignore
+        --compare-file-text-ignore-tags STRING1[,STRING2[,...]]
+                                     Tags that exclude a file resource from text comparison
         --[no-]preserve-environments Enable or disable environment preservation
         --environment STRING         Environment for catalog compilation globally
         --to-environment STRING      Environment for catalog compilation for the to branch
@@ -365,6 +367,21 @@ diffing activity. The catalog will be printed to STDOUT or written to the output
     </td>
     <td valign=top>
       Compare text, not source location, of file resources
+    </td>
+    <td valign=top>
+      When a file is specified with `source => 'puppet:///modules/something/foo.txt'`, remove
+the 'source' attribute and populate the 'content' attribute with the text of the file.
+This allows for a diff of the content, rather than a diff of the location, which is
+what is most often desired. (<a href="../lib/octocatalog-diff/cli/options/compare_file_text.rb">compare_file_text.rb</a>)
+    </td>
+  </tr>
+
+  <tr>
+    <td valign=top>
+      <pre><code>--compare-file-text-ignore-tags STRING1[,STRING2[,...]]</code></pre>
+    </td>
+    <td valign=top>
+      Tags that exclude a file resource from text comparison
     </td>
     <td valign=top>
       When a file is specified with `source => 'puppet:///modules/something/foo.txt'`, remove
@@ -1894,6 +1911,19 @@ Puppetserver for a v4 catalog API call. (<a href="../lib/octocatalog-diff/cli/op
       When using `--display-detail-add` by default the details of any field will be truncated
 at 80 characters. Specify `--no-truncate-details` to display the full output. This option
 has no effect when `--display-detail-add` is not used. (<a href="../lib/octocatalog-diff/cli/options/truncate_details.rb">truncate_details.rb</a>)
+    </td>
+  </tr>
+
+  <tr>
+    <td valign=top>
+      <pre><code>--use-lcs
+--no-use-lcs </code></pre>
+    </td>
+    <td valign=top>
+      Use the LCS algorithm to determine differences in arrays
+    </td>
+    <td valign=top>
+      Configures using the Longest common subsequence (LCS) algorithm to determine differences in arrays (<a href="../lib/octocatalog-diff/cli/options/use_lcs.rb">use_lcs.rb</a>)
     </td>
   </tr>
 

--- a/lib/octocatalog-diff/cli/options/compare_file_text.rb
+++ b/lib/octocatalog-diff/cli/options/compare_file_text.rb
@@ -15,3 +15,21 @@ OctocatalogDiff::Cli::Options::Option.newoption(:compare_file_text) do
     end
   end
 end
+
+# Sometimes there is a particular file resource for which the file text
+# comparison is not desired, while not disabling that option globally. Similar
+# to --ignore_tags, it's possible to tag the file resource and exempt it from
+# the --compare_file_text checks.
+# @param parser [OptionParser object] The OptionParser argument
+# @param options [Hash] Options hash being constructed; this is modified in this method.
+OctocatalogDiff::Cli::Options::Option.newoption(:compare_file_text_ignore_tags) do
+  has_weight 415
+
+  def parse(parser, options)
+    description = 'Tags that exclude a file resource from text comparison'
+    parser.on('--compare-file-text-ignore-tags STRING1[,STRING2[,...]]', Array, description) do |x|
+      options[:compare_file_text_ignore_tags] ||= []
+      options[:compare_file_text_ignore_tags].concat x
+    end
+  end
+end

--- a/spec/octocatalog-diff/fixtures/catalogs/catalog-test-file-v4-tagged.json
+++ b/spec/octocatalog-diff/fixtures/catalogs/catalog-test-file-v4-tagged.json
@@ -1,0 +1,57 @@
+{
+  "document_type": "Catalog",
+  "tags": ["settings","test"],
+  "name": "my.rspec.node",
+  "version": "production",
+  "environment": "production",
+  "resources": [
+    {
+      "type": "Stage",
+      "title": "main",
+      "tags": ["stage"],
+      "exported": false,
+      "parameters": {
+        "name": "main"
+      }
+    },
+    {
+      "type": "Class",
+      "title": "Settings",
+      "tags": ["class","settings"],
+      "exported": false
+    },
+    {
+      "type": "File",
+      "title": "/tmp/foo",
+      "tags": ["file","class"],
+      "file": "/x/modules/test/manifests/init.pp",
+      "line": 37,
+      "exported": false,
+      "parameters": {
+        "backup": false,
+        "mode": "0440",
+        "owner": "root",
+        "group": "root",
+        "source": "puppet:///modules/test/tmp/foo"
+      }
+    },
+    {
+      "type": "File",
+      "title": "/tmp/bar",
+      "tags": ["file","class","no_compare_tag"],
+      "file": "/x/modules/test/manifests/init.pp",
+      "line": 46,
+      "exported": false,
+      "parameters": {
+        "backup": false,
+        "mode": "0440",
+        "owner": "root",
+        "group": "root",
+        "source": "puppet:///modules/test/tmp/bar"
+      }
+    }
+ ],
+  "classes": [
+    "test"
+  ]
+}

--- a/spec/octocatalog-diff/fixtures/repos/convert-resources/broken/modules/test/manifests/init.pp
+++ b/spec/octocatalog-diff/fixtures/repos/convert-resources/broken/modules/test/manifests/init.pp
@@ -1,9 +1,11 @@
 class test {
   file { '/tmp/foo1':
+    tag    => ['_convert_file_resources_foo1_'],
     source => 'puppet:///modules/test/foo-new',
   }
 
   file { '/tmp/foo2':
+    tag    => ['_convert_file_resources_foo2_'],
     source => 'puppet:///modules/test/foo-old',
   }
 }

--- a/spec/octocatalog-diff/integration/convert_file_resources_spec.rb
+++ b/spec/octocatalog-diff/integration/convert_file_resources_spec.rb
@@ -147,7 +147,7 @@ describe 'convert file resources' do
     end
   end
 
-  context 'with broken repo' do
+  context 'with broken reference in to-catalog' do
     it 'should fail' do
       result = OctocatalogDiff::Integration.integration(
         spec_fact_file: 'facts.yaml',
@@ -160,8 +160,84 @@ describe 'convert file resources' do
       )
       expect(result[:exitcode]).to eq(-1)
       expect(result[:exception]).to be_a_kind_of(OctocatalogDiff::Errors::CatalogError)
-      expect(result[:exception].message).to match(/Errno::ENOENT/)
-      expect(result[:exception].message).to match(%r{Unable to resolve 'puppet:///modules/test/foo-new'})
+      expect(result[:exception].message).to match(%r{\AUnable to resolve source=>'puppet:///modules/test/foo-new' in File\[/tmp/foo1\] \(modules/test/manifests/init.pp:\d+\)\z}) # rubocop:disable Metrics/LineLength
+    end
+
+    context 'with --convert-file-resources-ignore-tags' do
+      before(:all) do
+        @result = OctocatalogDiff::Integration.integration(
+          spec_fact_file: 'facts.yaml',
+          spec_repo_old: 'convert-resources/old',
+          spec_repo_new: 'convert-resources/broken',
+          argv: [
+            '-n', 'rspec-node.github.net',
+            '--compare-file-text',
+            '--compare-file-text-ignore-tags', '_convert_file_resources_foo1_'
+          ]
+        )
+      end
+
+      it 'should compile the catalog' do
+        expect(@result[:exitcode]).not_to eq(-1), OctocatalogDiff::Integration.format_exception(@result)
+        expect(@result[:exitcode]).to eq(2), "Runtime error: #{@result[:logs]}"
+        expect(@result[:diffs]).to be_a_kind_of(Array)
+      end
+
+      it 'should leave /tmp/foo1 parameters:source alone in the new catalog' do
+        resource = {
+          diff_type: '!',
+          type: 'File',
+          title: '/tmp/foo1',
+          structure: %w(parameters source),
+          old_value: nil,
+          new_value: 'puppet:///modules/test/foo-new'
+        }
+        expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
+      end
+    end
+  end
+
+  context 'with broken reference in from-catalog' do
+    before(:all) do
+      @result = OctocatalogDiff::Integration.integration(
+        spec_fact_file: 'facts.yaml',
+        spec_repo_old: 'convert-resources/broken',
+        spec_repo_new: 'convert-resources/old',
+        argv: [
+          '-n', 'rspec-node.github.net',
+          '--compare-file-text'
+        ]
+      )
+    end
+
+    it 'should succeed' do
+      expect(@result[:exitcode]).not_to eq(-1), OctocatalogDiff::Integration.format_exception(@result)
+      expect(@result[:exitcode]).to eq(2), "Runtime error: #{@result[:logs]}"
+      expect(@result[:diffs]).to be_a_kind_of(Array)
+    end
+
+    it 'should leave /tmp/foo1 parameters:source alone in the old catalog' do
+      resource = {
+        diff_type: '!',
+        type: 'File',
+        title: '/tmp/foo1',
+        structure: %w(parameters source),
+        old_value: 'puppet:///modules/test/foo-new',
+        new_value: nil
+      }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
+    end
+
+    it 'should populate /tmp/foo1 parameters:content in the new catalog' do
+      resource = {
+        diff_type: '!',
+        type: 'File',
+        title: '/tmp/foo1',
+        structure: %w(parameters content),
+        old_value: nil,
+        new_value: "content of foo-old\n"
+      }
+      expect(OctocatalogDiff::Spec.diff_match?(@result[:diffs], resource)).to eq(true)
     end
   end
 
@@ -256,9 +332,7 @@ describe 'convert file resources' do
     it 'should fail' do
       expect(@result[:exitcode]).to eq(-1)
       expect(@result[:exception]).to be_a_kind_of(OctocatalogDiff::Errors::CatalogError)
-      expect(@result[:exception].message).to match(/Errno::ENOENT/)
-      rexp = Regexp.new(Regexp.escape("Unable to resolve '[\"puppet:///modules/test/foo-bar\""))
-      expect(@result[:exception].message).to match(rexp)
+      expect(@result[:exception].message).to match(%r{\AUnable to resolve source=>'\["puppet:///modules/test/foo-bar", "puppet:///modules/test/foo-baz"\]' in File\[/tmp/foo\] \(modules/test/manifests/array3.pp:\d+\)\z}) # rubocop:disable Metrics/LineLength
     end
   end
 end


### PR DESCRIPTION
## Overview

This pull request pertains to the feature of `octocatalog-diff` that substitutes the text of static files in place of the `source` attribute. This PR adds:

1. Bug fix - Do not error when the problem is with the "from" catalog and not the "to" catalog
2. Feature - Allow a tag to disable the feature on a per-resource basis
3. Improvement - Improve error message for broken reference
4. Docs - Create documentation for the original feature and the addition made in this PR

Unit tests were added for the new option and functionality, and of course coverage is 100%. Integration tests were also added for the new command line options and the overall disablement of the feature for the "from" catalog.

Specific details about the changes:

### Do not error when the problem is with the "from" catalog and not the "to" catalog

This change is partly motivated some work to fix broken `source => '...'` in resources. Even when we fix those in the "to" branch, it's not possible to use `octocatalog-diff` to analyze the changes because it always errors due to the "from" catalog. When we're working on fixing the problem, it is not useful to tell us that the original code base was broken and prevent us from using the tool for that reason. In this PR, there is no error raised by this problem in the "from" catalog (although of course the error is still raised if it's a problem in the "to" catalog).

### Allow a tag to disable the feature on a per-resource basis

This change is also motivated by a code base that has some `source => '...'` that point at dynamically added files that do not exist in the Puppet code repository (they're filled in by a different build process prior to the catalog being applied). We'd like to keep this feature enabled, but of course we would get an error due to the missing resources. Therefore, we want to skip certain resources that we know will be broken when this check is performed. This is implemented via tags, consistent with how `--ignore-tags` ignores entire resources based on tag.

### Improve error message for broken reference

The original error message cited the value in the `source` attribute, meaning that the developer would need to search the code base (and if it appeared multiple times, figure out which one it was). The new error message cites the name of the resource, the value of the `source` attribute, and the file name and line number of the Puppet manifest where the problem occurred.

### Create documentation for the original feature and the addition made in this PR

There was no documentation at all about the `--compare-file-text` feature, so I wrote some that documents the original feature as well as the tag-based mechanism to disable the feature that was introduced in this PR.

I also regenerated the options reference document via `bundle exec rake doc:build` which added my changes as well as an option from https://github.com/github/octocatalog-diff/pull/227 because it doesn't look like the doc got regenerated for that one.

## Checklist

- [x] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [x] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [x] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended.
- ~[ ] If you have added any new gem dependencies, make sure those gems are licensed under the MIT or Apache 2.0 license. We cannot add any dependencies on gems licensed under GPL.~
- ~[ ] If you have added any new gem dependencies, make sure you've checked in a copy of the `.gem` file into the [vendor/cache](https://github.com/github/octocatalog-diff/tree/master/vendor/cache) directory.~