### PR TITLE
Support nil / undef values for resource params

### DIFF
--- a/lib/octocatalog-diff/catalog-diff/differ.rb
+++ b/lib/octocatalog-diff/catalog-diff/differ.rb
@@ -558,7 +558,7 @@ module OctocatalogDiff
 
           # Added a new key that points to some kind of data structure that we know how
           # to handle.
-          classes = [String, Integer, Float, TrueClass, FalseClass, Array, Hash]
+          classes = [String, Integer, Float, TrueClass, FalseClass, Array, Hash, NilClass]
           if obj[1] =~ /^(.+)\f([^\f]+)$/ && OctocatalogDiff::Util::Util.object_is_any_of?(obj[2], classes)
             hashdiff_add_remove.add(obj[1])
             next


### PR DESCRIPTION
<!--
Hi there! We are delighted that you have chosen to contribute to octocatalog-diff.

If you have not already done so, please read our Contributing document, found here: https://github.com/github/octocatalog-diff/blob/master/.github/CONTRIBUTING.md

Please remember that all activity in this project, including pull requests, needs to comply with the Open Code of Conduct, found here: http://todogroup.org/opencodeofconduct/

Any contributions to this project must be made under the MIT license.

You do NOT need to bump the version number or regenerate the "Command line options reference" page. We will do this for you at or after the time we merge your contribution.
-->

## Overview

This pull request adds support for Nil values for resources in the catalog. Currently if any resource has a parameter explicitly set to undef / nil, octocatalog-diff raises an exception along the lines of:
```
bundler: failed to load command: octocatalog-diff (/builds/puppet/control-repo/vendor/bundle/bin/octocatalog-diff)
RuntimeError: Bug (please report): Unexpected data structure in hashdiff_result: ["+", "Class\fSomeClass\fparameters\fconfig\fSomeResoruce\fSomekey", nil]
  /builds/puppet/control-repo/vendor/bundle/gems/octocatalog-diff-2.1.0/lib/octocatalog-diff/catalog-diff/differ.rb:569:in `block in hashdiff_initial'
```

Having certain resource values is supported in puppet and is useful to certain patterns where we set a parameter if certain complex business logic is met otherwise leave as undef so the class/resource can use the default.

Note: I haven't added new tests as the existing ones cover adding the NilClass as a supported value.
## Checklist

- [x] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [x] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [x] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended.
- [x] If you have added any new gem dependencies, make sure those gems are licensed under the MIT or Apache 2.0 license. We cannot add any dependencies on gems licensed under GPL.
- [x] If you have added any new gem dependencies, make sure you've checked in a copy of the `.gem` file into the [vendor/cache](https://github.com/github/octocatalog-diff/tree/master/vendor/cache) directory.

/cc [related issues] [teams and individuals, making sure to mention why you're CC-ing them]
