### PR TITLE
Add "force" option for compare-file-text

### DIFF
--- a/doc/advanced-compare-file-text.md
+++ b/doc/advanced-compare-file-text.md
@@ -21,6 +21,7 @@ However, since applying the catalog could change the content of a file on the ta
 This feature is available only when the catalogs are being compiled from local code. This feature is not available, and will be automatically disabled, when pulling catalogs from PuppetDB or a Puppet server.
 
 Note: In Puppet >= 4.4 there is an option in Puppet itself called "static catalogs" which if enabled will cause the checksum of the file to be included in the catalog. However, the `octocatalog-diff` feature described here is still useful because it can be used to display a "diff" of the change rather than just displaying a "diff" of a checksum.
+
 ## Command line options
 
 ### `--compare-file-text` and `--no-compare-file-text`
@@ -38,6 +39,12 @@ settings[:compare_file_text] = false
 If this feature is disabled by default in a configuration file, add `--compare-file-text` to enable the feature for this specific run.
 
 Note that the feature will be automatically disabled, regardless of configuration or command line options, if catalogs are being pulled from PuppetDB or a Puppet server.
+
+### `--compare-file-text=force`
+
+To force the option to be on even in situations when it would be auto-disabled, set the command line argument `--compare-file-text=force`. When the Puppet source code is available, e.g. when compiling a catalog with `--catalog-only`, this will adjust the resulting catalog.
+
+If the Puppet source code is not available, forcing the feature on anyway may end up causing an exception. Use this option at your own risk.
 
 ### `--compare-file-text-ignore-tags`
 

--- a/lib/octocatalog-diff/cli/options/compare_file_text.rb
+++ b/lib/octocatalog-diff/cli/options/compare_file_text.rb
@@ -4,14 +4,30 @@
 # the 'source' attribute and populate the 'content' attribute with the text of the file.
 # This allows for a diff of the content, rather than a diff of the location, which is
 # what is most often desired.
+#
+# This has historically been a binary option, so --compare-file-text with no argument will
+# set this to `true` and --no-compare-file-text will set this to `false`. Note that
+# --no-compare-file-text does not accept an argument.
+#
+# File text comparison will be auto-disabled in circumstances other than compiling and
+# comparing two catalogs. To force file text comparison to be enabled at other times,
+# set --compare-file-text=force. This allows the content of the file to be substituted
+# in to --catalog-only compilations, for example.
+#
 # @param parser [OptionParser object] The OptionParser argument
 # @param options [Hash] Options hash being constructed; this is modified in this method.
 OctocatalogDiff::Cli::Options::Option.newoption(:compare_file_text) do
   has_weight 210
 
   def parse(parser, options)
-    parser.on('--[no-]compare-file-text', 'Compare text, not source location, of file resources') do |x|
-      options[:compare_file_text] = x
+    parser.on('--[no-]compare-file-text[=force]', 'Compare text, not source location, of file resources') do |x|
+      if x == 'force'
+        options[:compare_file_text] = :force
+      elsif x == true || x == false
+        options[:compare_file_text] = x
+      else
+        raise OptionParser::NeedlessArgument("needless argument: --compare-file-text=#{x}")
+      end
     end
   end
 end

--- a/lib/octocatalog-diff/util/catalogs.rb
+++ b/lib/octocatalog-diff/util/catalogs.rb
@@ -71,6 +71,12 @@ module OctocatalogDiff
         if @options.fetch(:compare_file_text, false)
           result.each do |_key, builder_obj|
             next if builder_obj.convert_file_resources(true)
+
+            if @options[:compare_file_text] == :force
+              @logger.debug "--compare-file-text is force-enabled even though it is not supported by #{builder_obj.builder}"
+              next
+            end
+
             @logger.debug "Disabling --compare-file-text; not supported by #{builder_obj.builder}"
             @options[:compare_file_text] = false
             catalog_tasks.map! do |x|

--- a/spec/octocatalog-diff/tests/cli/options/compare_file_text_spec.rb
+++ b/spec/octocatalog-diff/tests/cli/options/compare_file_text_spec.rb
@@ -4,6 +4,27 @@ require_relative '../options_helper'
 
 describe OctocatalogDiff::Cli::Options do
   describe '#opt_compare_file_text' do
-    include_examples 'true/false option', 'compare-file-text', :compare_file_text
+    it 'should set options[:compare_file_text] to true when --compare-file-text is set with no extra argument' do
+      result = run_optparse(['--compare-file-text'])
+      expect(result[:compare_file_text]).to eq(true)
+    end
+
+    it 'should set options[:compare_file_text] to :force when --compare-file-text is set to force' do
+      result = run_optparse(['--compare-file-text=force'])
+      expect(result[:compare_file_text]).to eq(:force)
+    end
+
+    it 'should set options[:compare_file_text] to false when --no-compare-file-text is set' do
+      result = run_optparse(['--no-compare-file-text'])
+      expect(result[:compare_file_text]).to eq(false)
+    end
+
+    it 'should raise if an unnecessary argument is passed to --compare-file-text' do
+      expect { run_optparse(['--no-compare-file-text=blah']) }.to raise_error(OptionParser::NeedlessArgument)
+    end
+
+    it 'should raise if an argument is passed to --no-compare-file-text' do
+      expect { run_optparse(['--no-compare-file-text=force']) }.to raise_error(OptionParser::NeedlessArgument)
+    end
   end
 end


### PR DESCRIPTION


## Overview

This pull request modifies the `--compare-file-text` option, which was previously just a binary option, to accept an additional parameter. There are now 3 behaviors:

- `--compare-file-text` -- Like before, enables the feature
- `--no-compare-file-text` -- Like before, disables the feature
- `--compare-file-text=force` -- New! Enables the feature, and doesn't let it be auto-disabled

We need this behavior because we're using `--catalog-only` in our workflow, and this currently auto-disables the feature because the second catalog in the non-existent diff is a "NoOp" catalog. With this change, our generated catalog will be populated with the content of static files rather than a reference to them, which is what we want.

I chose this implementation because it preserves existing behavior while still not introducing yet another command line argument. I added an integration test for this as well.

## Checklist

- [x] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [x] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [x] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended.
