### PR TITLE
Loosely pin puppet

### DIFF
--- a/octocatalog-diff.gemspec
+++ b/octocatalog-diff.gemspec
@@ -30,8 +30,8 @@ EOF
   s.add_runtime_dependency 'hashdiff', '>= 0.3.0'
   s.add_runtime_dependency 'parallel', '>= 1.12.0'
   s.add_runtime_dependency 'rugged', '>= 0.25.0b2'
-  s.add_runtime_dependency 'puppet',
-    ['>= 4.10.10', '< 8']
+  s.add_runtime_dependency 'puppet', '>= 4.10.10'
+  s.add_development_dependency 'puppet', '>= 4.10.10'
   s.add_development_dependency 'rspec', '~> 3.4.0'
   s.add_development_dependency 'rake', '12.3.3'
   s.add_development_dependency 'parallel_tests', '2.7.1'

--- a/octocatalog-diff.gemspec
+++ b/octocatalog-diff.gemspec
@@ -30,20 +30,8 @@ EOF
   s.add_runtime_dependency 'hashdiff', '>= 0.3.0'
   s.add_runtime_dependency 'parallel', '>= 1.12.0'
   s.add_runtime_dependency 'rugged', '>= 0.25.0b2'
-  if puppet_version == '4.10.10'
-    s.add_runtime_dependency 'puppet', '4.10.10'
-    s.add_development_dependency 'puppet', '4.10.10'
-  elsif puppet_version == '5.5.22'
-    s.add_runtime_dependency 'puppet', '5.5.22'
-    s.add_development_dependency 'puppet', '5.5.22'
-  elsif puppet_version == '6.18.0'
-    s.add_runtime_dependency 'puppet', '6.18.0'
-    s.add_development_dependency 'puppet', '6.18.0'
-  elsif puppet_version == '7.3.0'
-    s.add_runtime_dependency 'puppet', '7.3.0'
-    s.add_development_dependency 'puppet', '7.3.0'
-  end
-
+  s.add_runtime_dependency 'puppet',
+    ['>= 4.10.10', '< 8']
   s.add_development_dependency 'rspec', '~> 3.4.0'
   s.add_development_dependency 'rake', '12.3.3'
   s.add_development_dependency 'parallel_tests', '2.7.1'

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -26,6 +26,9 @@ fi
 mkdir -p "${DIR}/.git/hooks/" 2>/dev/null
 ln -fs "${DIR}/script/git-pre-commit" "${DIR}/.git/hooks/pre-commit"
 
+# Install specific version of puppet
+[[ ! -z $PUPPET_VERSION ]] && gem install puppet -v $PUPPET_VERSION
+
 # Create the .puppet_version file for use during CI
 # This value is consumed by script/puppet.
 if [ -f "${DIR}/Gemfile.lock" ]; then


### PR DESCRIPTION
<!--
Hi there! We are delighted that you have chosen to contribute to octocatalog-diff.

If you have not already done so, please read our Contributing document, found here: https://github.com/github/octocatalog-diff/blob/master/.github/CONTRIBUTING.md

Please remember that all activity in this project, including pull requests, needs to comply with the Open Code of Conduct, found here: http://todogroup.org/opencodeofconduct/

Any contributions to this project must be made under the MIT license.

You do NOT need to bump the version number or regenerate the "Command line options reference" page. We will do this for you at or after the time we merge your contribution.
-->

## Overview

This pull request pins puppet more loosely.

Originally, I wanted to do something like:

`'>= 4.10.10', '< 5', '>= 5.-----'`

But it doesn't seem like that style of version specification is supported. Instead, I'm pinning the minimum and pushing the issue of installing non-vulnerable puppet versions to whatever library installs this one. 

## Checklist

- [ ] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [ ] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [ ] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended.
- [ ] If you have added any new gem dependencies, make sure those gems are licensed under the MIT or Apache 2.0 license. We cannot add any dependencies on gems licensed under GPL.
- [ ] If you have added any new gem dependencies, make sure you've checked in a copy of the `.gem` file into the [vendor/cache](https://github.com/github/octocatalog-diff/tree/master/vendor/cache) directory.

/cc [related issues] [teams and individuals, making sure to mention why you're CC-ing them]
