### PR TITLE
limiting group matches to 1000 chars at most

### DIFF
--- a/lib/octocatalog-diff/catalog-diff/display/text.rb
+++ b/lib/octocatalog-diff/catalog-diff/display/text.rb
@@ -307,10 +307,7 @@ module OctocatalogDiff
         # @param string_in [String] Input string, which might contain trailing whitespace
         # @return [String] Modified string
         def self.make_trailing_whitespace_visible(string_in)
-          if string_in.length > 1000
-            raise ArgumentError, "Input string too long"
-          end
-          return string_in unless string_in =~ /\A((?:.|\n)*?)(\s+)(\e\[0m)?\Z/
+          return string_in unless string_in =~ /\A((?:.|\n){1,1000}?)(\s+)(\e\[0m)?\Z/
           beginning = Regexp.last_match(1)
           trailing_space = Regexp.last_match(2)
           end_escape = Regexp.last_match(3)

--- a/lib/octocatalog-diff/catalog-util/builddir.rb
+++ b/lib/octocatalog-diff/catalog-util/builddir.rb
@@ -155,7 +155,7 @@ module OctocatalogDiff
         elsif options[:fact_file]
           raise Errno::ENOENT, "Fact file #{options[:fact_file]} does not exist" unless File.file?(options[:fact_file])
           fact_file_opts = { fact_file_string: File.read(options[:fact_file]) }
-          fact_file_opts[:backend] = Regexp.last_match(1).to_sym if options[:fact_file] =~ /.*\.(\w){1,1000}$/
+          fact_file_opts[:backend] = Regexp.last_match(1).to_sym if options[:fact_file] =~ /.{1,1000}\.(\w)*$/
           OctocatalogDiff::Facts.new(fact_file_opts)
         else
           raise ArgumentError, 'No facts passed to "install_fact_file" method'

--- a/lib/octocatalog-diff/catalog-util/builddir.rb
+++ b/lib/octocatalog-diff/catalog-util/builddir.rb
@@ -155,10 +155,7 @@ module OctocatalogDiff
         elsif options[:fact_file]
           raise Errno::ENOENT, "Fact file #{options[:fact_file]} does not exist" unless File.file?(options[:fact_file])
           fact_file_opts = { fact_file_string: File.read(options[:fact_file]) }
-          if options[:fact_file].length > 1000
-            raise ArgumentError, "Input too long"
-          end
-          fact_file_opts[:backend] = Regexp.last_match(1).to_sym if options[:fact_file] =~ /.*\.(\w+)$/
+          fact_file_opts[:backend] = Regexp.last_match(1).to_sym if options[:fact_file] =~ /.*\.(\w{1,1000})$/
           OctocatalogDiff::Facts.new(fact_file_opts)
         else
           raise ArgumentError, 'No facts passed to "install_fact_file" method'

--- a/lib/octocatalog-diff/catalog-util/builddir.rb
+++ b/lib/octocatalog-diff/catalog-util/builddir.rb
@@ -155,7 +155,7 @@ module OctocatalogDiff
         elsif options[:fact_file]
           raise Errno::ENOENT, "Fact file #{options[:fact_file]} does not exist" unless File.file?(options[:fact_file])
           fact_file_opts = { fact_file_string: File.read(options[:fact_file]) }
-          fact_file_opts[:backend] = Regexp.last_match(1).to_sym if options[:fact_file] =~ /.{1,1000}\.(\w)*$/
+          fact_file_opts[:backend] = Regexp.last_match(1).to_sym if options[:fact_file] =~ /.{1,1000}\.(\w+)$/
           OctocatalogDiff::Facts.new(fact_file_opts)
         else
           raise ArgumentError, 'No facts passed to "install_fact_file" method'

--- a/lib/octocatalog-diff/catalog-util/builddir.rb
+++ b/lib/octocatalog-diff/catalog-util/builddir.rb
@@ -155,7 +155,7 @@ module OctocatalogDiff
         elsif options[:fact_file]
           raise Errno::ENOENT, "Fact file #{options[:fact_file]} does not exist" unless File.file?(options[:fact_file])
           fact_file_opts = { fact_file_string: File.read(options[:fact_file]) }
-          fact_file_opts[:backend] = Regexp.last_match(1).to_sym if options[:fact_file] =~ /.*\.(\w{1,1000})$/
+          fact_file_opts[:backend] = Regexp.last_match(1).to_sym if options[:fact_file] =~ /.*\.(\w){1,1000}$/
           OctocatalogDiff::Facts.new(fact_file_opts)
         else
           raise ArgumentError, 'No facts passed to "install_fact_file" method'


### PR DESCRIPTION
<!--
Hi there! We are delighted that you have chosen to contribute to octocatalog-diff.

If you have not already done so, please read our Contributing document, found here: https://github.com/github/octocatalog-diff/blob/master/.github/CONTRIBUTING.md

Please remember that all activity in this project, including pull requests, needs to comply with the Open Code of Conduct, found here: http://todogroup.org/opencodeofconduct/

Any contributions to this project must be made under the MIT license.

You do NOT need to bump the version number or regenerate the "Command line options reference" page. We will do this for you at or after the time we merge your contribution.
-->

## Overview

This pull request [introduces/changes/removes] [functionality/feature].

(Please write a summary of your pull request here. This paragraph should go into detail about what is changing, the motivation behind this change, and the approach you took.)

## Checklist

- [ ] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [ ] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [ ] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended.
- [ ] If you have added any new gem dependencies, make sure those gems are licensed under the MIT or Apache 2.0 license. We cannot add any dependencies on gems licensed under GPL.
- [ ] If you have added any new gem dependencies, make sure you've checked in a copy of the `.gem` file into the [vendor/cache](https://github.com/github/octocatalog-diff/tree/master/vendor/cache) directory.

/cc [related issues] [teams and individuals, making sure to mention why you're CC-ing them]
