### PR TITLE
CodeQL - Limit polynomial regex to only match 1000 characters at most

### DIFF
--- a/lib/octocatalog-diff/catalog-util/command.rb
+++ b/lib/octocatalog-diff/catalog-util/command.rb
@@ -91,7 +91,7 @@ module OctocatalogDiff
         facts_terminus = @options.fetch(:facts_terminus, 'yaml')
         if facts_terminus == 'yaml'
           cmdline << "--factpath=#{Shellwords.escape(File.join(@compilation_dir, 'var', 'yaml', 'facts'))}"
-          if @options[:fact_file].is_a?(String) && @options[:fact_file] =~ /.*\.(\w+)$/
+          if @options[:fact_file].is_a?(String) && @options[:fact_file] =~ /.*{1,1000}\.(\w+)$/
             fact_file = File.join(@compilation_dir, 'var', 'yaml', 'facts', "#{@node}.#{Regexp.last_match(1)}")
             FileUtils.cp @options[:fact_file], fact_file unless File.file?(fact_file) || @options[:fact_file] == fact_file
           end

--- a/spec/octocatalog-diff/tests/util/parallel_spec.rb
+++ b/spec/octocatalog-diff/tests/util/parallel_spec.rb
@@ -343,8 +343,8 @@ describe OctocatalogDiff::Util::Parallel do
       expect(two_result.exception).to eq(nil)
       expect(two_result.output).to match(/^two def \d+$/)
 
-      one_time = Regexp.last_match(1).to_i if one_result.output =~ /(\d+)$/
-      two_time = Regexp.last_match(1).to_i if two_result.output =~ /(\d+)$/
+      one_time = Regexp.last_match(1).to_i if one_result.output =~ /(\d+{1,1000})$/
+      two_time = Regexp.last_match(1).to_i if two_result.output =~ /(\d+{1,1000})$/
       expect(one_time).to be < two_time
     end
 


### PR DESCRIPTION
<!--
Hi there! We are delighted that you have chosen to contribute to octocatalog-diff.

If you have not already done so, please read our Contributing document, found here: https://github.com/github/octocatalog-diff/blob/master/.github/CONTRIBUTING.md

Please remember that all activity in this project, including pull requests, needs to comply with the Open Code of Conduct, found here: http://todogroup.org/opencodeofconduct/

Any contributions to this project must be made under the MIT license.

You do NOT need to bump the version number or regenerate the "Command line options reference" page. We will do this for you at or after the time we merge your contribution.
-->

## Overview

This pull request [introduces/changes/removes] [functionality/feature].

(Please write a summary of your pull request here. This paragraph should go into detail about what is changing, the motivation behind this change, and the approach you took.)

## Checklist

- [ ] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [ ] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [ ] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended.
- [ ] If you have added any new gem dependencies, make sure those gems are licensed under the MIT or Apache 2.0 license. We cannot add any dependencies on gems licensed under GPL.
- [ ] If you have added any new gem dependencies, make sure you've checked in a copy of the `.gem` file into the [vendor/cache](https://github.com/github/octocatalog-diff/tree/master/vendor/cache) directory.

/cc [related issues] [teams and individuals, making sure to mention why you're CC-ing them]
