### PR TITLE
fix "undefined method `=~' for false:FalseClass" on Ruby >= 3.2

### DIFF
--- a/lib/octocatalog-diff/catalog-diff/display/text.rb
+++ b/lib/octocatalog-diff/catalog-diff/display/text.rb
@@ -367,12 +367,13 @@ module OctocatalogDiff
 
           # Single line strings
           hash.keys.sort.map do |key|
-            next if hash[key] =~ /\n/
+            next if hash[key].kind_of?(String) && hash[key] =~ /\n/
             result << left_pad(2 * depth + 4, [key.inspect, ': ', hash[key].inspect].join('')).green
           end
 
           # Multi-line strings
           hash.keys.sort.map do |key|
+            next if !hash[key].kind_of?(String)
             next if hash[key] !~ /\n/
             result << left_pad(2 * depth + 4, [key.inspect, ': >>>'].join('')).green
             result.concat hash[key].split(/\n/).map(&:green)

--- a/spec/octocatalog-diff/tests/catalog-diff/display/text_spec.rb
+++ b/spec/octocatalog-diff/tests/catalog-diff/display/text_spec.rb
@@ -254,7 +254,8 @@ describe OctocatalogDiff::CatalogDiff::Display::Text do
                   'mode' => '0644',
                   'content' => 'x' * 150,
                   'owner' => 'root',
-                  'group' => 'wheel'
+                  'group' => 'wheel',
+                  'force' => true,
                 }
               }
             ]


### PR DESCRIPTION


<!--
Hi there! We are delighted that you have chosen to contribute to octocatalog-diff.

If you have not already done so, please read our Contributing document, found here: https://github.com/github/octocatalog-diff/blob/master/.github/CONTRIBUTING.md

Please remember that all activity in this project, including pull requests, needs to comply with the Open Code of Conduct, found here: http://todogroup.org/opencodeofconduct/

Any contributions to this project must be made under the MIT license.

You do NOT need to bump the version number or regenerate the "Command line options reference" page. We will do this for you at or after the time we merge your contribution.
-->

## Overview

This fixes an error that happens with Ruby 3.2, because the removal from https://bugs.ruby-lang.org/issues/15231

## Checklist

- [ ] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [ ] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [ ] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended.
- [ ] If you have added any new gem dependencies, make sure those gems are licensed under the MIT or Apache 2.0 license. We cannot add any dependencies on gems licensed under GPL.
- [ ] If you have added any new gem dependencies, make sure you've checked in a copy of the `.gem` file into the [vendor/cache](https://github.com/github/octocatalog-diff/tree/master/vendor/cache) directory.

/cc [related issues] [teams and individuals, making sure to mention why you're CC-ing them]
