### PR TITLE
Add ability to set storeconfig_backends

### DIFF
--- a/examples/octocatalog-diff.cfg.rb
+++ b/examples/octocatalog-diff.cfg.rb
@@ -164,6 +164,14 @@ module OctocatalogDiff
       settings[:storeconfigs] = false
 
       ##############################################################################################
+      # storeconfigs_backend
+      #  Override the default `storeconfigs` backend of `puppetdb`
+      #  valid options include `puppetdb`, `yaml`, `json`
+      ##############################################################################################
+
+      setings[:storeconfigs_backend] = 'puppetdb'
+      
+      ##############################################################################################
       # bootstrap_script
       #   When you check out your Puppet repository, do you need to run a script to prepare that
       #   repository for use? For example, maybe you need to run librarian-puppet to install

--- a/examples/octocatalog-diff.cfg.rb
+++ b/examples/octocatalog-diff.cfg.rb
@@ -169,7 +169,7 @@ module OctocatalogDiff
       #  valid options include `puppetdb`, `yaml`, `json`
       ##############################################################################################
 
-      setings[:storeconfigs_backend] = 'puppetdb'
+      settings[:storeconfigs_backend] = 'puppetdb'
       
       ##############################################################################################
       # bootstrap_script

--- a/lib/octocatalog-diff/catalog-util/command.rb
+++ b/lib/octocatalog-diff/catalog-util/command.rb
@@ -72,7 +72,12 @@ module OctocatalogDiff
 
         # storeconfigs?
         if @options[:storeconfigs]
-          cmdline.concat %w(--storeconfigs --storeconfigs_backend=puppetdb)
+          if @options[:storeconfigs_backend]
+            cmdline << '--storeconfigs'
+            cmdline << "--storeconfigs_backend=#{Shellwords.escape(@options[:storeconfigs_backend])}"
+          else
+            cmdline.concat %w(--storeconfigs --storeconfigs_backend=puppetdb)
+          end
         else
           cmdline << '--no-storeconfigs'
         end

--- a/lib/octocatalog-diff/cli.rb
+++ b/lib/octocatalog-diff/cli.rb
@@ -43,6 +43,7 @@ module OctocatalogDiff
       compare_file_text: true,
       display_datatype_changes: true,
       parallel: true,
+      storeconfigs_backend: 'puppetdb',
       suppress_absent_file_details: true,
       hiera_path: 'hieradata',
       use_lcs: true

--- a/lib/octocatalog-diff/cli/options/storeconfigs_backend.rb
+++ b/lib/octocatalog-diff/cli/options/storeconfigs_backend.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Set storeconfigs (integration with PuppetDB for collected resources)
+# @param parser [OptionParser object] The OptionParser argument
+# @param options [Hash] Options hash being constructed; this is modified in this method.
+OctocatalogDiff::Cli::Options::Option.newoption(:storeconfigs) do
+  has_weight 220
+
+  def parse(parser, options)
+    parser.on('--storeconfigs-backend TERMINUS', 'Set the terminus used for storeconfigs') do |x|
+      options[:storeconfigs_backend] = x
+    end
+  end
+end

--- a/spec/octocatalog-diff/tests/cli/options/storeconfigs_backend_spec.rb
+++ b/spec/octocatalog-diff/tests/cli/options/storeconfigs_backend_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative '../options_helper'
+
+describe OctocatalogDiff::Cli::Options do
+  describe '#opt_storeconfigs_backend' do
+    it 'should accept all valid arguments' do
+      result = run_optparse(['--storeconfigs-backend', 'puppetdb,yaml,json'])
+      expect(result[:validate_references]).to eq(%w(puppetdb yaml json))
+    end
+  end
+end

--- a/spec/octocatalog-diff/tests/cli/options/storeconfigs_backend_spec.rb
+++ b/spec/octocatalog-diff/tests/cli/options/storeconfigs_backend_spec.rb
@@ -5,8 +5,8 @@ require_relative '../options_helper'
 describe OctocatalogDiff::Cli::Options do
   describe '#opt_storeconfigs_backend' do
     it 'should accept all valid arguments' do
-      result = run_optparse(['--storeconfigs-backend', 'puppetdb,yaml,json'])
-      expect(result[:validate_references]).to eq(%w(puppetdb yaml json))
+      result = run_optparse(['--storeconfigs-backend', 'puppetdb'])
+      expect(result[:storeconfigs_backend]).to eq('puppetdb')
     end
   end
 end

--- a/spec/octocatalog-diff/tests/cli_spec.rb
+++ b/spec/octocatalog-diff/tests/cli_spec.rb
@@ -31,6 +31,7 @@ describe OctocatalogDiff::Cli do
           colors: true,
           debug: false,
           quiet: false,
+          storeconfigs_backend: 'puppetdb',
           format: :color_text,
           display_source_file_line: false,
           compare_file_text: true,


### PR DESCRIPTION


## Overview

This pull request adds the ability to set the `storeconfigs_backend` option.  This allows for the selection of alternate backends for storing catalog data.

The change allows the `octocatalog-diff` command to now accept the paramater `--storeconfigs-backend [puppetdb|yaml|json]` which sets the terminus for storeconfigs on the underlying `puppet catalog compile` command.

The default for `storeconfigs_backend` has been defaulted to `puppetdb` to maintain backwards compatibility.
## Checklist

- [x] Make sure that all of the tests pass, and fix any that don't. Just run `rake` in your checkout directory, or review the CI job triggered whenever you push to a pull request.
- [ ] Make sure that there is 100% [test coverage](https://github.com/github/octocatalog-diff/blob/master/doc/dev/coverage.md) by running `rake coverage:spec` or ignoring untestable sections of code with `# :nocov` comments. If you need help getting to 100% coverage please ask; however, don't just submit code with no tests.
- [ ] If you have added a new command line option, we would greatly appreciate a corresponding [integration test](https://github.com/github/octocatalog-diff/blob/master/doc/dev/integration-tests.md) that exercises it from start to finish. This is optional but recommended.
- [ ] If you have added any new gem dependencies, make sure those gems are licensed under the MIT or Apache 2.0 license. We cannot add any dependencies on gems licensed under GPL.
- [ ] If you have added any new gem dependencies, make sure you've checked in a copy of the `.gem` file into the [vendor/cache](https://github.com/github/octocatalog-diff/tree/master/vendor/cache) directory.

/cc [related issues] [teams and individuals, making sure to mention why you're CC-ing them]
