### PR TITLE
JSON-safe comma splitting for override options (--fact-override, --enc-override)

### DIFF
--- a/doc/advanced-override-facts.md
+++ b/doc/advanced-override-facts.md
@@ -18,6 +18,8 @@ To override a fact in the "from" catalog:
 
 You may use as many of these arguments as you wish to adjust as many facts as you wish.
 
+These options support specifying multiple overrides as a comma-separated list. Commas inside JSON values (for example, arrays) will not be treated as separators. You may also repeat the option.
+
 ## Examples
 
 Simulate a change to its IP address in the "to" branch:

--- a/doc/optionsref.md
+++ b/doc/optionsref.md
@@ -68,9 +68,9 @@ Usage: octocatalog-diff [command line options]
                                      References to validate
         --[no-]compare-file-text[=force]
                                      Compare text, not source location, of file resources
+        --[no-]storeconfigs          Enable integration with puppetdb for collected resources
         --storeconfigs-backend TERMINUS
                                      Set the terminus used for storeconfigs
-        --[no-]storeconfigs          Enable integration with puppetdb for collected resources
         --retry-failed-catalog N     Retry building a failed catalog N times
         --no-enc                     Disable ENC
         --enc PATH                   Path to ENC script, relative to checkout directory or absolute

--- a/lib/octocatalog-diff/cli/options/enc_override.rb
+++ b/lib/octocatalog-diff/cli/options/enc_override.rb
@@ -7,15 +7,21 @@ OctocatalogDiff::Cli::Options::Option.newoption(:enc_override) do
   has_weight 322
 
   def parse(parser, options)
-    # Set 'enc_override_in' because more processing is needed, once the command line options
-    # have been parsed, to make this into the final form 'enc_override'.
-    OctocatalogDiff::Cli::Options.option_globally_or_per_branch(
-      parser: parser,
-      options: options,
-      cli_name: 'enc-override',
-      option_name: 'enc_override_in',
-      desc: 'Override parameter from ENC',
-      datatype: []
-    )
+    parser.on('--enc-override STRING1[,STRING2[,...]]', 'Override parameter from ENC globally') do |x|
+      options[:to_enc_override_in] ||= []
+      options[:from_enc_override_in] ||= []
+      OctocatalogDiff::Cli::Options.split_override_list(x).each do |item|
+        options[:to_enc_override_in] << item
+        options[:from_enc_override_in] << item
+      end
+    end
+    parser.on('--to-enc-override STRING1[,STRING2[,...]]', 'Override parameter from ENC for the to branch') do |x|
+      options[:to_enc_override_in] ||= []
+      OctocatalogDiff::Cli::Options.split_override_list(x).each { |item| options[:to_enc_override_in] << item }
+    end
+    parser.on('--from-enc-override STRING1[,STRING2[,...]]', 'Override parameter from ENC for the from branch') do |x|
+      options[:from_enc_override_in] ||= []
+      OctocatalogDiff::Cli::Options.split_override_list(x).each { |item| options[:from_enc_override_in] << item }
+    end
   end
 end

--- a/lib/octocatalog-diff/cli/options/fact_override.rb
+++ b/lib/octocatalog-diff/cli/options/fact_override.rb
@@ -10,19 +10,21 @@ OctocatalogDiff::Cli::Options::Option.newoption(:fact_override) do
     # Set 'fact_override_in' because more processing is needed, once the command line options
     # have been parsed, to make this into the final form 'fact_override'.
     # Avoid Array parsing here so JSON values with commas stay intact.
-    parser.on('--fact-override STRING', 'Override fact globally') do |x|
+    parser.on('--fact-override STRING1[,STRING2[,...]]', 'Override fact globally') do |x|
       options[:to_fact_override_in] ||= []
       options[:from_fact_override_in] ||= []
-      options[:to_fact_override_in] << x
-      options[:from_fact_override_in] << x
+      OctocatalogDiff::Cli::Options.split_override_list(x).each do |item|
+        options[:to_fact_override_in] << item
+        options[:from_fact_override_in] << item
+      end
     end
-    parser.on('--to-fact-override STRING', 'Override fact for the to branch') do |x|
+    parser.on('--to-fact-override STRING1[,STRING2[,...]]', 'Override fact for the to branch') do |x|
       options[:to_fact_override_in] ||= []
-      options[:to_fact_override_in] << x
+      OctocatalogDiff::Cli::Options.split_override_list(x).each { |item| options[:to_fact_override_in] << item }
     end
-    parser.on('--from-fact-override STRING', 'Override fact for the from branch') do |x|
+    parser.on('--from-fact-override STRING1[,STRING2[,...]]', 'Override fact for the from branch') do |x|
       options[:from_fact_override_in] ||= []
-      options[:from_fact_override_in] << x
+      OctocatalogDiff::Cli::Options.split_override_list(x).each { |item| options[:from_fact_override_in] << item }
     end
   end
 end

--- a/lib/octocatalog-diff/cli/options/fact_override.rb
+++ b/lib/octocatalog-diff/cli/options/fact_override.rb
@@ -9,13 +9,20 @@ OctocatalogDiff::Cli::Options::Option.newoption(:fact_override) do
   def parse(parser, options)
     # Set 'fact_override_in' because more processing is needed, once the command line options
     # have been parsed, to make this into the final form 'fact_override'.
-    OctocatalogDiff::Cli::Options.option_globally_or_per_branch(
-      parser: parser,
-      options: options,
-      cli_name: 'fact-override',
-      option_name: 'fact_override_in',
-      desc: 'Override fact',
-      datatype: []
-    )
+    # Avoid Array parsing here so JSON values with commas stay intact.
+    parser.on('--fact-override STRING', 'Override fact globally') do |x|
+      options[:to_fact_override_in] ||= []
+      options[:from_fact_override_in] ||= []
+      options[:to_fact_override_in] << x
+      options[:from_fact_override_in] << x
+    end
+    parser.on('--to-fact-override STRING', 'Override fact for the to branch') do |x|
+      options[:to_fact_override_in] ||= []
+      options[:to_fact_override_in] << x
+    end
+    parser.on('--from-fact-override STRING', 'Override fact for the from branch') do |x|
+      options[:from_fact_override_in] ||= []
+      options[:from_fact_override_in] << x
+    end
   end
 end

--- a/spec/octocatalog-diff/tests/cli/options/enc_override_spec.rb
+++ b/spec/octocatalog-diff/tests/cli/options/enc_override_spec.rb
@@ -11,5 +11,19 @@ describe OctocatalogDiff::Cli::Options do
       result = run_optparse(args)
       expect(result[:to_enc_override_in]).to eq(['foo=bar', 'baz=buzz'])
     end
+
+    it 'should accept a comma-separated list of overrides' do
+      args = ['--enc-override', 'foo=bar,baz=buzz']
+      result = run_optparse(args)
+      expect(result[:to_enc_override_in]).to eq(['foo=bar', 'baz=buzz'])
+      expect(result[:from_enc_override_in]).to eq(['foo=bar', 'baz=buzz'])
+    end
+
+    it 'should split comma-separated overrides but not split commas inside JSON' do
+      args = ['--enc-override', 'foo=bar,json_list=(json)["a","b"],baz=buzz']
+      result = run_optparse(args)
+      expect(result[:to_enc_override_in]).to eq(['foo=bar', 'json_list=(json)["a","b"]', 'baz=buzz'])
+      expect(result[:from_enc_override_in]).to eq(['foo=bar', 'json_list=(json)["a","b"]', 'baz=buzz'])
+    end
   end
 end

--- a/spec/octocatalog-diff/tests/cli/options/fact_override_spec.rb
+++ b/spec/octocatalog-diff/tests/cli/options/fact_override_spec.rb
@@ -11,5 +11,12 @@ describe OctocatalogDiff::Cli::Options do
       result = run_optparse(args)
       expect(result[:to_fact_override_in]).to eq(['foo=bar', 'baz=buzz'])
     end
+
+    it 'should not split JSON overrides containing commas' do
+      args = ['--fact-override', 'json_list=(json)["a","b","c"]']
+      result = run_optparse(args)
+      expect(result[:to_fact_override_in]).to eq(['json_list=(json)["a","b","c"]'])
+      expect(result[:from_fact_override_in]).to eq(['json_list=(json)["a","b","c"]'])
+    end
   end
 end

--- a/spec/octocatalog-diff/tests/cli/options/fact_override_spec.rb
+++ b/spec/octocatalog-diff/tests/cli/options/fact_override_spec.rb
@@ -18,5 +18,19 @@ describe OctocatalogDiff::Cli::Options do
       expect(result[:to_fact_override_in]).to eq(['json_list=(json)["a","b","c"]'])
       expect(result[:from_fact_override_in]).to eq(['json_list=(json)["a","b","c"]'])
     end
+
+    it 'should accept a comma-separated list of overrides' do
+      args = ['--fact-override', 'foo=bar,baz=buzz']
+      result = run_optparse(args)
+      expect(result[:to_fact_override_in]).to eq(['foo=bar', 'baz=buzz'])
+      expect(result[:from_fact_override_in]).to eq(['foo=bar', 'baz=buzz'])
+    end
+
+    it 'should split comma-separated overrides but not split commas inside JSON' do
+      args = ['--fact-override', 'foo=bar,json_list=(json)["a","b"],baz=buzz']
+      result = run_optparse(args)
+      expect(result[:to_fact_override_in]).to eq(['foo=bar', 'json_list=(json)["a","b"]', 'baz=buzz'])
+      expect(result[:from_fact_override_in]).to eq(['foo=bar', 'json_list=(json)["a","b"]', 'baz=buzz'])
+    end
   end
 end


### PR DESCRIPTION
## Summary
This PR restores support for comma-separated override lists while preserving JSON values that contain commas (e.g., JSON arrays). It also refactors the parsing logic into a shared helper to avoid duplication across override option classes.
 
## What changed
 
### Override parsing
- `--fact-override`, `--to-fact-override`, `--from-fact-override` now accept:
  - `STRING1[,STRING2[,...]]`
- Commas are treated as separators **only when they are outside** of quoted strings and JSON structures (`[]` / `{}`), so values like:
  - `json_list=(json)["a","b"]`
  remain intact.
 
### DRY refactor
- Added shared helper:
  - [OctocatalogDiff::Cli::Options.split_override_list](cci:1://file:///home/isaiah/snow_laptop/work/dev/forks/octocatalog-diff/lib/octocatalog-diff/cli/options.rb:180:6-243:9) in [lib/octocatalog-diff/cli/options.rb](cci:7://file:///home/isaiah/snow_laptop/work/dev/forks/octocatalog-diff/lib/octocatalog-diff/cli/options.rb:0:0-0:0)
- Updated override option implementations to use the helper:
  - [lib/octocatalog-diff/cli/options/fact_override.rb](cci:7://file:///home/isaiah/snow_laptop/work/dev/forks/octocatalog-diff/lib/octocatalog-diff/cli/options/fact_override.rb:0:0-0:0)
  - [lib/octocatalog-diff/cli/options/enc_override.rb](cci:7://file:///home/isaiah/snow_laptop/work/dev/forks/octocatalog-diff/lib/octocatalog-diff/cli/options/enc_override.rb:0:0-0:0)
 
### Tests
- Added/updated specs to cover:
  - comma-separated override lists
  - mixed lists with JSON values containing commas
- Specs:
  - [spec/octocatalog-diff/tests/cli/options/fact_override_spec.rb](cci:7://file:///home/isaiah/snow_laptop/work/dev/forks/octocatalog-diff/spec/octocatalog-diff/tests/cli/options/fact_override_spec.rb:0:0-0:0)
  - [spec/octocatalog-diff/tests/cli/options/enc_override_spec.rb](cci:7://file:///home/isaiah/snow_laptop/work/dev/forks/octocatalog-diff/spec/octocatalog-diff/tests/cli/options/enc_override_spec.rb:0:0-0:0)
 
### Docs
- Updated facts override docs to describe comma-separated list support + JSON-safe behavior:
  - [doc/advanced-override-facts.md](cci:7://file:///home/isaiah/snow_laptop/work/dev/forks/octocatalog-diff/doc/advanced-override-facts.md:0:0-0:0)
- Updated CLI options reference for fact overrides:
  - [doc/optionsref.md](cci:7://file:///home/isaiah/snow_laptop/work/dev/forks/octocatalog-diff/doc/optionsref.md:0:0-0:0)
 
## Why
Previously, comma-separated lists were disabled to avoid breaking JSON values (since JSON arrays/objects contain commas). This PR enables both:
- convenience: `foo=bar,baz=buzz`
- correctness: `json_list=(json)["a","b","c"]`
 
## Testing
```bash
bundle exec rspec \
  spec/octocatalog-diff/tests/cli/options/fact_override_spec.rb \
  spec/octocatalog-diff/tests/cli/options/enc_override_spec.rb