### PR TITLE
Enhance absent_file filter to suppress diffs when file is absent in b…

### DIFF
--- a/lib/octocatalog-diff/catalog-diff/differ.rb
+++ b/lib/octocatalog-diff/catalog-diff/differ.rb
@@ -202,7 +202,9 @@ module OctocatalogDiff
         filter_opts = {
           logger: @logger,
           from_compilation_dir: @catalog1_raw.compilation_dir,
-          to_compilation_dir: @catalog2_raw.compilation_dir
+          to_compilation_dir: @catalog2_raw.compilation_dir,
+          from_resources: @catalog1_raw.resources,
+          to_resources: @catalog2_raw.resources
         }
         OctocatalogDiff::CatalogDiff::Filter.apply_filters(result, @opts[:filters], filter_opts) if @opts[:filters].any?
 

--- a/lib/octocatalog-diff/catalog-diff/filter/absent_file.rb
+++ b/lib/octocatalog-diff/catalog-diff/filter/absent_file.rb
@@ -10,6 +10,7 @@ module OctocatalogDiff
       # Filter out changes in parameters when the "to" resource has ensure => absent.
       class AbsentFile < OctocatalogDiff::CatalogDiff::Filter
         KEEP_ATTRIBUTES = (Set.new %w(ensure backup force provider)).freeze
+        ABSENT_VALUES = ['absent', 'false', false].freeze
 
         # Constructor: Since this filter requires knowledge of the entire array of diffs,
         # override the inherited method to store those diffs in an instance variable.
@@ -28,8 +29,8 @@ module OctocatalogDiff
         # @param diff [OctocatalogDiff::API::V1::Diff] Difference
         # @param _options [Hash] Additional options (there are none for this filter)
         # @return [Boolean] true if this difference is a YAML file with identical objects, false otherwise
-        def filtered?(diff, _options = {})
-          build_results if @results.nil?
+        def filtered?(diff, options = {})
+          build_results(options) if @results.nil?
           @results.include?(diff)
         end
 
@@ -37,25 +38,60 @@ module OctocatalogDiff
 
         # Private: The first time `.filtered?` is called, build up the cache of results.
         # Returns nothing, but populates @results.
-        def build_results
-          # Which files can we ignore?
-          @files_to_ignore = Set.new
+        def build_results(options)
+          @files_absent_in_to = Set.new
+          @files_absent_in_from = Set.new
+
+          if options[:to_resources].is_a?(Array)
+            options[:to_resources].each do |resource|
+              next unless resource.is_a?(Hash) && resource['type'] == 'File'
+              next unless resource.key?('parameters') && resource['parameters'].is_a?(Hash)
+              next unless ABSENT_VALUES.include?(resource['parameters']['ensure'])
+              @files_absent_in_to.add file_title_for_resource(resource)
+            end
+          end
+
+          if options[:from_resources].is_a?(Array)
+            options[:from_resources].each do |resource|
+              next unless resource.is_a?(Hash) && resource['type'] == 'File'
+              next unless resource.key?('parameters') && resource['parameters'].is_a?(Hash)
+              next unless ABSENT_VALUES.include?(resource['parameters']['ensure'])
+              @files_absent_in_from.add file_title_for_resource(resource)
+            end
+          end
+
+          # Backward-compatible behavior: if an ensure diff explicitly shows ensure => absent in the new
+          # catalog, make sure we ignore that file even if resource lists were not provided.
           @diffs.each do |diff|
             next unless diff.change? && diff.type == 'File' && diff.structure == %w(parameters ensure)
-            next unless ['absent', 'false', false].include?(diff.new_value)
-            @files_to_ignore.add diff.title
+            next unless ABSENT_VALUES.include?(diff.new_value)
+            @files_absent_in_to.add diff.title
           end
+
+          @files_absent_in_both = @files_absent_in_to & @files_absent_in_from
 
           # Based on that, which diffs can we ignore?
           @results = Set.new @diffs.reject { |diff| keep_diff?(diff) }
+        end
+
+        def file_title_for_resource(resource)
+          return resource['title'] unless resource.key?('parameters') && resource['parameters'].is_a?(Hash)
+          return resource['title'] unless resource['parameters'].key?('path')
+
+          resource['parameters']['path']
         end
 
         # Private: Determine whether to keep a particular diff.
         # @param diff [OctocatalogDiff::API::V1::Diff] Difference under consideration
         # @return [Boolean] true = keep, false = discard
         def keep_diff?(diff)
-          return true unless diff.change? && diff.type == 'File' && diff.structure.first == 'parameters'
-          return true unless @files_to_ignore.include?(diff.title)
+          return true unless diff.change? && diff.type == 'File'
+
+          # If both catalogs declare the same file as absent, suppress all diffs for that file.
+          return false if @files_absent_in_both.include?(diff.title)
+
+          return true unless diff.structure.first == 'parameters'
+          return true unless @files_absent_in_to.include?(diff.title)
           return true if KEEP_ATTRIBUTES.include?(diff.structure.last)
           false
         end


### PR DESCRIPTION
…oth catalogs

Pass from_resources and to_resources to filter options, add logic to detect files with ensure=>absent in both catalogs, and suppress all parameter diffs for those files. Maintains backward compatibility by checking ensure diffs when resource lists are not provided.

## Summary
When the [AbsentFile](cci:2://file:///home/isaiah/snow_laptop/work/dev/forks/octocatalog-diff/lib/octocatalog-diff/catalog-diff/filter/absent_file.rb:10:6-97:9) filter is enabled, `octocatalog-diff` should not show diffs for resources that are `ensure => absent` in **both** catalogs, even if other parameters differ. If both sides are absent for the same resource key, those parameter differences are meaningless and should be suppressed.
 
This PR fixes a case where we would still emit diffs when both catalogs had `ensure == absent` but other params differed.
 
## Problem
Today, [AbsentFile](cci:2://file:///home/isaiah/snow_laptop/work/dev/forks/octocatalog-diff/lib/octocatalog-diff/catalog-diff/filter/absent_file.rb:10:6-97:9) filtering primarily triggers based on seeing an explicit `ensure` diff (e.g., `present -> absent`). If a file is absent in both catalogs, there may be no `ensure` diff at all, but we could still show diffs for other parameters (owner/mode/etc.) if they change.
 
That output is noise: if the file is absent in both catalogs, the params don’t matter.
 
## Changes
 
### Pass full resource lists to filters
- Updated [lib/octocatalog-diff/catalog-diff/differ.rb](cci:7://file:///home/isaiah/snow_laptop/work/dev/forks/octocatalog-diff/lib/octocatalog-diff/catalog-diff/differ.rb:0:0-0:0) to pass:
  - `from_resources: @catalog1_raw.resources`
  - `to_resources: @catalog2_raw.resources`
  into the filter options hash.
- This allows filters to reason about the full catalog state, not just diff hunks.
 
### Improve [AbsentFile](cci:2://file:///home/isaiah/snow_laptop/work/dev/forks/octocatalog-diff/lib/octocatalog-diff/catalog-diff/filter/absent_file.rb:10:6-97:9) filter behavior
- Updated [lib/octocatalog-diff/catalog-diff/filter/absent_file.rb](cci:7://file:///home/isaiah/snow_laptop/work/dev/forks/octocatalog-diff/lib/octocatalog-diff/catalog-diff/filter/absent_file.rb:0:0-0:0):
  - The filter now tracks files that are absent in:
    - the **to** catalog
    - the **from** catalog
    - **both** catalogs
  - If a file is absent in **both** catalogs, the filter suppresses *all* diffs for that file (even if other params differ).
  - Preserved backwards-compatible behavior where an explicit `ensure => absent` diff in the new catalog is still sufficient to trigger filtering even when resource lists aren’t provided.
 
## Tests
- Added coverage to ensure diffs are suppressed when the same file is absent in both catalogs:
  - [spec/octocatalog-diff/tests/catalog-diff/filter/absent_file_spec.rb](cci:7://file:///home/isaiah/snow_laptop/work/dev/forks/octocatalog-diff/spec/octocatalog-diff/tests/catalog-diff/filter/absent_file_spec.rb:0:0-0:0)
 
Run:
```bash
bundle exec rspec spec/octocatalog-diff/tests/catalog-diff/filter/absent_file_spec.rb
